### PR TITLE
fix error in connect_to_forum if user not found

### DIFF
--- a/src/connect_to_forum/main.py
+++ b/src/connect_to_forum/main.py
@@ -272,7 +272,7 @@ def main(event: Dict[str, bytes], context: str) -> None:
     if message_in_ascii:
         f_usr_id = get_user_id(f_username)
 
-        if f_usr_id != 0:
+        if f_usr_id:
             block_of_user_data = get_user_attributes(f_usr_id)
 
             if block_of_user_data:


### PR DESCRIPTION
```
Exception on /_ah/push-handlers/pubsub/projects/lizaalert-bot-01/topics/parse_user_profile_from_forum [POST]
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/flask/app.py", line 2529, in wsgi_app
    response = self.full_dispatch_request()
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/functions_framework/execution_id.py", line 106, in wrapper
    return view_function(*args, **kwargs)
  File "/layers/google.python.pip/pip/lib/python3.10/site-packages/functions_framework/__init__.py", line 237, in view_func
    function(data, context)
  File "/workspace/main.py", line 303, in main
    cur.execute(
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type integer: ""
LINE 4:         values (1234567, '', 'non-varified', '2025-02-07T...
                                    ^

```