### PR TITLE
format messages for vk

### DIFF
--- a/src/_dependencies/vk_api.py
+++ b/src/_dependencies/vk_api.py
@@ -24,18 +24,20 @@ class VKApi:
     ) -> dict:
         # https://dev.vk.com/ru/method/messages.send
         query: dict[str, Any] = {
-            'user_id': user_id,
+            'peer_id': user_id,
             'random_id': random_id,
             'v': self.API_VERSION,
-            'message': message,
             'lat': lat,
             'long': long,
-            'keyboard': keyboard,
+            'message': message,
+            # 'parse_mode': 'markdown_v2',
             # 'keyboard': '',  # https://dev.vk.com/ru/api/bots/development/keyboard
         }
-
+        payload: dict[str, Any] = {
+            # 'keyboard': keyboard,
+        }
         url = '/method/messages.send'
-        resp = self._session.post(url, json={}, params=query)
+        resp = self._session.post(url, json=payload, params=query)
         resp.raise_for_status()
         resp_data = resp.json()
         assert 'error' not in resp_data

--- a/src/send_notifications/main.py
+++ b/src/send_notifications/main.py
@@ -3,6 +3,7 @@
 import ast
 import datetime
 import logging
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
 from contextlib import contextmanager
@@ -10,7 +11,6 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any, Iterator, List
 
-import requests
 import sqlalchemy
 from sqlalchemy.engine.base import Connection, Engine
 
@@ -258,7 +258,11 @@ def send_single_message(tg_api: TGApiBase, vk_api: VKApi, message_to_send: Messa
         if USE_VK_API and message_to_send.vk_id:
             try:
                 logging.info(f'Sending message to VK: {message_to_send.vk_id=} {message_to_send=}')
-                vk_api.send(message_to_send.vk_id, message_to_send.message_id, message_content)
+                vk_api.send(
+                    message_to_send.vk_id,
+                    message_to_send.message_id,
+                    format_mesage_for_vk(message_content),
+                )
             except Exception:
                 logging.exception(f'Sending message to VK: failed {message_to_send.vk_id=} {message_to_send=}')
 
@@ -274,7 +278,7 @@ def send_single_message(tg_api: TGApiBase, vk_api: VKApi, message_to_send: Messa
                     message_to_send.message_id,
                     '',
                     lat=message_params['latitude'],
-                    long=message_params['latitude'],
+                    long=message_params['longitude'],
                 )
             except Exception:
                 logging.exception(f'Sending message to VK: failed {message_to_send.vk_id=} {message_to_send=}')
@@ -493,3 +497,42 @@ def main(event: dict, context: Ctx) -> str | None:
     logging.info('script finished')
 
     return 'ok'
+
+
+def format_mesage_for_vk(message: str) -> str:
+    # Handle different types of <a> tags based on their href
+    # Pattern to match <a href="URL">text</a>
+    a_tag_pattern = re.compile(r'<a\s+href="([^"]+)"[^>]*>([^<]+)</a>')
+
+    def replace_a_tag(match: re.Match) -> str:
+        url = match.group(1)
+        text = match.group(2)
+
+        # Rule 1: For links starting with https://lizaalert.org/forum/memberlist.php
+        # Remove the link but keep the text
+        if url.startswith('https://lizaalert.org/forum/memberlist.php'):
+            return text
+
+        # Rule 2: For links starting with https://lizaalert.org/forum/viewtopic.php and containing "start" in query
+        # Remove the link but keep the text
+        if url.startswith('https://lizaalert.org/forum/viewtopic.php') and 'start=' in url:
+            return text
+
+        # Rule 3: For phone number links (tel:)
+        # Remove the link but keep the text
+        if url.startswith('tel:'):
+            return text
+
+        # Rule 4: For other links (including lizaalert.org/forum/viewtopic.php without start),
+        # unfold the link: show URL followed by text
+        return f'{url} {text}'
+
+    # Replace all <a> tags
+    result = a_tag_pattern.sub(replace_a_tag, message)
+
+    # Remove any remaining HTML tags (including self-closing tags)
+    # Pattern matches < followed by any characters (non-greedy) up to >
+    html_tag_pattern = re.compile(r'<[^>]+>')
+    result = html_tag_pattern.sub('', result)
+
+    return result

--- a/tests/test_send_notifications.py
+++ b/tests/test_send_notifications.py
@@ -163,32 +163,14 @@ def test_get_notifications_1():
     assert any(x.message_id == notif_failed_six_minutes_ago.message_id for x in messages)
 
 
-@pytest.mark.skip(reason='performance test')
-class TestPerformance:
-    def test_generate_message_batch(self):
-        for _ in range(1000):
-            with suppress(Exception):
-                # cant set unique mailing_id
-                NotSentNotificationFactory.create_sync()
-
-    @pytest.mark.parametrize('batch_size', [1, 10, 100])
-    def test_queries_performance(self, benchmark, batch_size: int, connection: Connection):
-        # benchmark something
-
-        with patch('send_notifications.main.MESSAGES_BATCH_SIZE', batch_size):
-            benchmark(main.get_notifs_to_send, connection, True)
-
-
-class TestSendVK:
-    def test_foo(self):
-        pass
-
-
 @pytest.mark.skip(reason='Real run')
 class TestSendVKReal:
     def test_send_via_client(self):
         import os
         import random
+
+        message_html = 'НЖ – изменение статуса по <a href="https://lizaalert.org/forum/viewtopic.php?t=123">Иванова ж40 лет</a> (Москва и МО – Активные поиски)'
+        message_md = 'hello!\nsecond string - **bold**\n[link here](vk.com/foo)'
 
         apikey = os.getenv('VK_API_KEY')
         my_user_id = os.getenv('VK_USER_ID')  # TODO
@@ -197,8 +179,59 @@ class TestSendVKReal:
         resp_data = cln.send(
             user_id=my_user_id,
             random_id=randint,
-            message='hello',
-            lat='56.839356',
-            long='60.608865',
+            # message=message_md,
+            message=message_html,
+            # lat='56.839356',
+            # long='60.608865',
         )
         assert 'error' not in resp_data
+
+
+class TestFormatMessageForVK:
+    @pytest.mark.parametrize(
+        'input,result',
+        [
+            (
+                'НЖ <a href="https://lizaalert.org/forum/viewtopic.php?t=123">Иванова ж40 лет</a> (Самара)',
+                'НЖ https://lizaalert.org/forum/viewtopic.php?t=123 Иванова ж40 лет (Самара)',
+                # unfold links starting with lizaalert.org/forum/viewtopic.php
+            ),
+            (
+                'Комментарии от <a href="https://lizaalert.org/forum/memberlist.php?mode=viewprofile&amp;u=107175">Странник_klg</a>:',
+                'Комментарии от Странник_klg:',
+                # remove whole links starting with https://lizaalert.org/forum/memberlist.php
+            ),
+            (
+                '«<a href="https://lizaalert.org/forum/viewtopic.php?&amp;t=367030&amp;start=36">Странник_klg, в экипаже с Амрита, РВП позже   </a>',
+                '«Странник_klg, в экипаже с Амрита, РВП позже   ',
+                # remove whole links starting with https://lizaalert.org/forum/viewtopic.php and containing "start" in query
+            ),
+            (
+                '<i>some text and other links</i>',
+                'some text and other links',
+                # remove italic
+            ),
+            (
+                '<s>some text and other links</s>',
+                'some text and other links',
+                # remove strikethrough
+            ),
+            (
+                '<b>some text and other links</b>',
+                'some text and other links',
+                # remove bold
+            ),
+            (
+                ' <a href="tel:+79001234567"> ☎️+79001234567</a>»',
+                '  ☎️+79001234567»',
+                # remove whole link like phone numbers tel:+79001234567
+            ),
+            (
+                '<b> <a href="tel:+79001234567"> ☎️+79001234567</a>»</b>',
+                '  ☎️+79001234567»',
+                # remove nested hrefs too
+            ),
+        ],
+    )
+    def test_format(self, input: str, result: str):
+        assert main.format_mesage_for_vk(input) == result


### PR DESCRIPTION
- fix bug with coordinates
- format messages for vk: there is no option in VK API to format messages with html/markdown.
