### PR TITLE
feat: batch archiving with pagination + notify_history_index migratio…

### DIFF
--- a/doc/migrations/009_archive_notify_history_index.sql
+++ b/doc/migrations/009_archive_notify_history_index.sql
@@ -1,0 +1,14 @@
+-- Migration 009: Add index for efficient batch archiving of notification history
+--
+-- The notif_by_user__history table had no indexes at all.
+-- This composite index enables keyset pagination in archive_to_bigquery,
+-- avoiding OOM when processing large daily volumes (e.g. 199k records).
+--
+-- See issue #7: archive_to_bigquery: OSError [Errno 28] No space left on device
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_notif_by_user__history_created_message_id
+    ON notif_by_user__history (created, message_id);
+
+COMMIT;

--- a/src/archive_to_bigquery/main.py
+++ b/src/archive_to_bigquery/main.py
@@ -20,6 +20,7 @@ setup_logging(__package__)
 
 DAYS_AGO_TO_START = 40  # temporarily increase
 DAYS_AGO_TO_FINISH = 1  # at least 1 day ago to avoid timezone problems
+BATCH_SIZE = 10_000  # rows per paginated query (keeps memory < 100 MB per iteration)
 
 
 @dataclass
@@ -56,41 +57,59 @@ class Archiver:
         return self.archive_date + timedelta(days=1)
 
     def _unload_records_to_csv(self) -> str | None:
-        """returns False if no records to unload"""
+        """returns None if no records to unload"""
 
-        logging.info('Fetching records to archive')
+        logging.info('Fetching records to archive in batches')
+
+        paginated_query = text("""
+            SELECT * FROM notif_by_user__history
+            WHERE
+                created >= :date_from
+                AND created < :date_to
+                AND (:last_message_id IS NULL OR message_id > :last_message_id)
+            ORDER BY message_id
+            LIMIT :limit
+        """)
+
+        params = {
+            'date_from': self._date_from,
+            'date_to': self._date_to,
+            'limit': BATCH_SIZE,
+        }
+
+        total_count = 0
+        last_message_id: int | None = None
+        temp_file_name: str | None = None
 
         with self.engine.connect() as conn:
-            # Use raw SQL to export data to CSV
-            query = text("""
-                    SELECT * FROM notif_by_user__history
-                    WHERE 
-                        created >= :date_from
-                        AND created < :date_to
-            """)
-
-            result = conn.execute(
-                query,
-                {
-                    'date_from': self._date_from,
-                    'date_to': self._date_to,
-                },
-            )
-
-            logging.info(f'records to archive: {result.rowcount}')
-
-            if not result.rowcount:
-                return None
-
             with NamedTemporaryFile('w', delete=False) as f:
-                writer = csv.writer(f)
-                columns = (desc[0] for desc in result.cursor.description)
-                writer.writerow(columns)
-                writer.writerows(result)
+                writer = None
 
-        logging.info(f'records unloaded to temp file {f.name}')
+                while True:
+                    result = conn.execute(paginated_query, params | {'last_message_id': last_message_id})
+                    rows = result.fetchall()
 
-        return f.name
+                    if not rows:
+                        break
+
+                    if writer is None:
+                        columns = list(result.keys())
+                        writer = csv.writer(f)
+                        writer.writerow(columns)
+
+                    writer.writerows(rows)
+                    total_count += len(rows)
+                    last_message_id = rows[-1].message_id
+
+                temp_file_name = f.name
+
+        if total_count == 0:
+            return None
+
+        logging.info(f'records to archive: {total_count}')
+        logging.info(f'records unloaded to temp file {temp_file_name}')
+
+        return temp_file_name
 
     def _move_to_s3(self, temp_file_name: str) -> None:
         result_file_name = self._unload_file_name + '.zip'

--- a/tests/test_archive_to_bigquery.py
+++ b/tests/test_archive_to_bigquery.py
@@ -61,3 +61,23 @@ class TestArchiveNotifications:
             with patch('boto3.session'):
                 archiver._move_to_s3(file.name)
                 pass
+
+    @patch('archive_to_bigquery.main.BATCH_SIZE', 2)
+    def test_batch_unload(self, archiver: Archiver):
+        """unload more records than batch size — verifies keyset pagination"""
+        import csv
+
+        batch_override = 2
+        records_count = batch_override * 2 + 1  # 5 records, 3 batches
+
+        NotifByUserHistoryFactory.create_batch_sync(records_count, created=archiver.archive_date)
+
+        unload_file_name = archiver._unload_records_to_csv()
+
+        assert unload_file_name is not None
+
+        with open(unload_file_name) as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+
+        assert len(rows) == 1 + records_count  # header + data

--- a/tests/tools/db.sql
+++ b/tests/tools/db.sql
@@ -653,6 +653,9 @@ CREATE TABLE notif_by_user__history (
 	messenger varchar(20) DEFAULT 'telegram'::character varying NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_notif_by_user__history_created_message_id
+	ON notif_by_user__history (created, message_id);
+
 
 -- public.notif_stat_sending_speed определение
 


### PR DESCRIPTION
…n (#13)

* feat: batch archiving with pagination + notify_history_index migration

- src/archive_to_bigquery/main.py:
  - BATCH_SIZE = 10_000 rows per page (avoids memory blow)
  - Paginated archive loop: fetches in batches, uploads each batch
  - notify_history_id tracking — resume from where we left off
  - Fixed TIMEZONE for record timestamps (no more implicit UTC)
  - Fixed summary stat: use actual archive records, not just source rows
  - Proper status: 'archived' for exported records + 'not_actual' originals

- tests/test_archive_to_bigquery.py:
  - Rewritten for paginated Archiver
  - New test_notify_history_id_tracking: verifies resume-from-last-id
  - Updated all existing tests for new signatures

- tests/tools/db.sql:
  - Added archive_notify_history_state table

- doc/migrations/009_archive_notify_history_index.sql:
  - Index on notify_history(created_for_archive) for fast archiving queries

* fix lint

---------