### PR TITLE
perf: per-folder timestamp tracking for check_topics_by_u…

### DIFF
--- a/src/check_topics_by_upd_time/_legacy/main.py
+++ b/src/check_topics_by_upd_time/_legacy/main.py
@@ -70,6 +70,7 @@ def get_db_client() -> DBClient:
 class FolderForDecompose:
     mother_folder_num: str
     mother_folder_name: str | None = None
+    mother_folder_timestamp: str | None = None
 
 
 @dataclass
@@ -109,6 +110,7 @@ def get_session() -> requests.Session:
 class KeyValueStorage:
     # TODO rename and move to common code
     ROOT_MODIFIED_TIMES_KEY = 'root_modified_times'
+    FOLDER_TIMESTAMPS_KEY = 'folder_timestamps'
 
     def __init__(self) -> None:
         self.db = get_db_client()
@@ -131,6 +133,13 @@ class KeyValueStorage:
 
     def write_foder_root_modified_times_dict(self, data: dict) -> None:
         return self._write_snapshot(data, self.ROOT_MODIFIED_TIMES_KEY)
+
+    def read_folder_timestamps(self) -> dict[str, str]:
+        ts: dict | None = self._read_snapshot(self.FOLDER_TIMESTAMPS_KEY)
+        return ts if ts else {}
+
+    def write_folder_timestamps(self, data: dict[str, str]) -> None:
+        return self._write_snapshot(data, self.FOLDER_TIMESTAMPS_KEY)
 
     def _read_snapshot(self, snapshot_name: str) -> Any:
         return self.db.get_key_value_item(snapshot_name)
@@ -374,23 +383,12 @@ def time_delta(now: datetime.datetime, time: datetime.datetime) -> int:
     return time_diff_in_min
 
 
-def get_the_list_folders_to_update(list_of_folders_and_times: list[list]) -> list:
-    """get the list of updated folders that were updated recently"""
-    storage = KeyValueStorage()
-    update_times = storage.read_foder_root_modified_times_dict()
-    updated_folders = []
-
-    for f_num, f_time_str, f_time in list_of_folders_and_times:
-        saved_update_time = update_times.get(f_num, datetime.datetime.min)
-        if f_time_str != saved_update_time:
-            updated_folders.append([f_num, f_time_str])
-            update_times[f_num] = f_time_str
-
-    storage.write_foder_root_modified_times_dict(update_times)
-    return updated_folders
-
-
-def get_updated_root_folders() -> list[str]:
+def get_updated_root_folders() -> list[tuple[str, str]]:
+    """
+    Get root folders whose timestamps changed since last check.
+    Returns list of (folder_num, timestamp_str).
+    Does NOT save timestamps — caller is responsible on success.
+    """
     now = datetime.datetime.now()
     folder_checker = FolderUpdateChecker()
     list_of_folders_and_times = folder_checker.check_updates_in_folder_with_folders()
@@ -402,11 +400,28 @@ def get_updated_root_folders() -> list[str]:
     time_diff_in_min = time_delta(now, last_update_time)
     logging.info(f'{str(time_diff_in_min)} minute(s) ago forum was updated')
 
-    list_of_updated_folders = get_the_list_folders_to_update(list_of_folders_and_times)
-    logging.info(f'Folders with new info: {str(list_of_updated_folders)}')
+    storage = KeyValueStorage()
+    update_times = storage.read_foder_root_modified_times_dict()
+    updated_folders: list[tuple[str, str]] = []
 
-    updated_root_folders = [line[0] for line in list_of_updated_folders]
-    return updated_root_folders
+    for f_num, f_time_str, f_time in list_of_folders_and_times:
+        saved_update_time = update_times.get(f_num, datetime.datetime.min)
+        if f_time_str != saved_update_time:
+            updated_folders.append((str(f_num), str(f_time_str)))
+
+    logging.info(f'Root folders with new info: {str(updated_folders)}')
+    return updated_folders
+
+
+def save_root_timestamps(updated_root_folders: list[tuple[str, str]]) -> None:
+    """Persist root folder timestamps after successful tree traversal."""
+    if not updated_root_folders:
+        return
+    storage = KeyValueStorage()
+    update_times = storage.read_foder_root_modified_times_dict()
+    for f_num, f_time_str in updated_root_folders:
+        update_times[f_num] = f_time_str
+    storage.write_foder_root_modified_times_dict(update_times)
 
 
 def process_folder(
@@ -414,7 +429,15 @@ def process_folder(
     updated_folders: list,
     folder: FolderForDecompose,
     storage: KeyValueStorage,
+    folder_timestamps: dict[str, str],
 ) -> None:
+    # Skip if this folder's timestamp hasn't changed since last successful check
+    if folder.mother_folder_timestamp:
+        saved_ts = folder_timestamps.get(folder.mother_folder_num)
+        if saved_ts == folder.mother_folder_timestamp:
+            logging.info(f'Folder {folder.mother_folder_num}: no change since last check, skipping')
+            return
+
     decomposed_folder = FolderDecomposer().decompose_folder(folder.mother_folder_num)
 
     new_child_folders_str = str(decomposed_folder.subfolders)
@@ -431,31 +454,53 @@ def process_folder(
 
     logging.info(f'List of new folders in {folder.mother_folder_num}: {list_of_new_folders}')
 
+    # Save this folder's timestamp
+    if folder.mother_folder_timestamp:
+        folder_timestamps[folder.mother_folder_num] = folder.mother_folder_timestamp
+
+    # Queue only new/changed subfolders (from comparator), carrying their timestamps
+    child_timestamps = {str(sf.folder_num): sf.change_time_str for sf in decomposed_folder.subfolders}
     for line in list_of_new_folders:
-        folders_to_check.append(FolderForDecompose(mother_folder_num=str(line)))
+        folders_to_check.append(
+            FolderForDecompose(
+                mother_folder_num=str(line),
+                mother_folder_timestamp=child_timestamps.get(str(line)),
+            )
+        )
 
     if new_child_searches_str != old_child_searches_str:
         updated_folders.append((folder.mother_folder_num, folder.mother_folder_name))
 
 
-def get_updates_of_nested_folders(folders_list_to_scan: list[str]) -> list[list]:
+def get_updates_of_nested_folders(folders_list_to_scan: list[tuple[str, str]]) -> list[list]:
     storage = KeyValueStorage()
+    folder_timestamps = storage.read_folder_timestamps()
 
     folders_to_check: list[FolderForDecompose] = []
     updated_folders: list = []
 
-    for folder_num in folders_list_to_scan:
-        folders_to_check.append(FolderForDecompose(mother_folder_num=folder_num))
+    for folder_num, folder_timestamp in folders_list_to_scan:
+        folders_to_check.append(
+            FolderForDecompose(
+                mother_folder_num=folder_num,
+                mother_folder_timestamp=folder_timestamp,
+            )
+        )
 
     with ThreadPoolExecutor(max_workers=WORKERS_COUNT) as pool:
         futures = []
         while folders_to_check:
             while folders_to_check:
                 folder = folders_to_check.pop()
-                future = pool.submit(process_folder, folders_to_check, updated_folders, folder, storage)
+                future = pool.submit(
+                    process_folder, folders_to_check, updated_folders, folder, storage, folder_timestamps
+                )
                 futures.append(future)
             wait(futures)
             [f.result() for f in futures]  # check that all tasks are done without exceptions
+
+    # Save per-folder timestamps for future runs
+    storage.write_folder_timestamps(folder_timestamps)
     return updated_folders
 
 
@@ -467,10 +512,17 @@ def main(event: dict[str, Any], context: Ctx | None = None) -> None:
     if not updated_root_folders:
         return
 
-    updated_folders = get_updates_of_nested_folders(updated_root_folders)
-    logging.info(
-        'The below list is to be sent to "Identify updates of topics" script via pub/sub:\n%s',
-        updated_folders,
-    )
-    if updated_folders:
-        pubsub_parse_folders(updated_folders)
+    try:
+        updated_folders = get_updates_of_nested_folders(updated_root_folders)
+        logging.info(
+            'The below list is to be sent to "Identify updates of topics" script via pub/sub:\n%s',
+            updated_folders,
+        )
+        if updated_folders:
+            pubsub_parse_folders(updated_folders)
+    except Exception:
+        logging.exception('Failed to traverse nested folders — root timestamps NOT saved')
+        raise
+
+    # Only save root timestamps after successful full traversal
+    save_root_timestamps(updated_root_folders)

--- a/tests/test_check_topics_by_upd_time/test_legacy_main.py
+++ b/tests/test_check_topics_by_upd_time/test_legacy_main.py
@@ -1,0 +1,361 @@
+"""Tests for check_topics_by_upd_time._legacy.main.
+
+Covers FolderComparator, process_folder timestamp skip logic,
+get_updated_root_folders, save_root_timestamps, and main().
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from check_topics_by_upd_time._legacy.main import (
+    DecomposedFolder,
+    FolderComparator,
+    FolderForDecompose,
+    FolderUpdateChecker,
+    KeyValueStorage,
+    Subfolder,
+    get_updated_root_folders,
+    process_folder,
+    save_root_timestamps,
+)
+
+pytestmark = pytest.mark.xdist_group('legacy_db')
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FolderComparator — pure logic
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFolderComparator:
+    """FolderComparator returns int folder nums (from ast.literal_eval).
+
+    A folder that exists in old but NOT in new appears as "changed" because
+    its old timestamp != the empty string in the comparison matrix.
+    """
+
+    @staticmethod
+    def _list(*items: tuple[str, str]) -> str:
+        return str([Subfolder(folder_num=int(k), change_time_str=v) for k, v in items])
+
+    def test_new_folders_all_returned(self):
+        assert FolderComparator().compare_folders(self._list(('100', 't1'), ('200', 't2')), None) == [100, 200]
+
+    def test_no_changes_returns_empty(self):
+        s = self._list(('100', 't1'))
+        assert FolderComparator().compare_folders(s, s) == []
+
+    def test_new_folder_added(self):
+        old = self._list(('100', 't1'))
+        new = self._list(('100', 't1'), ('200', 't2'))
+        assert FolderComparator().compare_folders(new, old) == [200]
+
+    def test_removed_folder_appears_as_changed(self):
+        old = self._list(('100', 't1'), ('200', 't2'))
+        new = self._list(('100', 't1'))
+        assert FolderComparator().compare_folders(new, old) == [200]
+
+    def test_timestamp_changed(self):
+        old = self._list(('100', 't1'))
+        new = self._list(('100', 't2'))
+        assert FolderComparator().compare_folders(new, old) == [100]
+
+    def test_mixed(self):
+        old = self._list(('100', 't1'), ('200', 't2'), ('300', 't3'))
+        new = self._list(('100', 't1'), ('200', 'tc'), ('400', 't4'))
+        assert sorted(FolderComparator().compare_folders(new, old)) == [200, 300, 400]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# process_folder — timestamp skip logic
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProcessFolderTimestampSkip:
+    """process_folder should skip HTTP fetch when the folder timestamp hasn't changed.
+
+    The skip check works on the *in-memory* folder_timestamps dict.
+    storage is mocked to avoid DB / HTTP dependencies.
+    """
+
+    def _run(self, folder, folder_timestamps=None, child_subfolders=None):
+        if folder_timestamps is None:
+            folder_timestamps = {}
+        if child_subfolders is None:
+            child_subfolders = [Subfolder(folder_num=111, change_time_str='child_ts')]
+
+        folders_to_check: list = []
+        updated_folders: list = []
+        storage = MagicMock(spec=KeyValueStorage)
+        # storage.read_folders / read_searches must return strings for FolderComparator
+        storage.read_folders.return_value = None
+        storage.read_searches.return_value = None
+
+        with patch('check_topics_by_upd_time._legacy.main.FolderDecomposer', autospec=True) as mock_cls:
+            inst = mock_cls.return_value
+            inst.decompose_folder.return_value = DecomposedFolder(
+                subfolders=child_subfolders,
+                searches=[],
+                folder_name='test',
+            )
+            process_folder(folders_to_check, updated_folders, folder, storage, folder_timestamps)
+
+        return folders_to_check, updated_folders, inst
+
+    def test_skip_when_timestamp_matches(self):
+        """Saved ts == mother_folder_timestamp → skip."""
+        folders_to_check, updated_folders, mock_inst = self._run(
+            FolderForDecompose(mother_folder_num='123', mother_folder_timestamp='ts1'),
+            {'123': 'ts1'},
+        )
+        mock_inst.decompose_folder.assert_not_called()
+        assert folders_to_check == []
+        assert updated_folders == []
+
+    def test_process_when_no_timestamp(self):
+        """mother_folder_timestamp is None → process."""
+        folders_to_check, updated_folders, mock_inst = self._run(
+            FolderForDecompose(mother_folder_num='999', mother_folder_timestamp=None),
+        )
+        mock_inst.decompose_folder.assert_called_once_with('999')
+        assert len(folders_to_check) == 1
+
+    def test_process_when_timestamp_mismatch(self):
+        """Saved ts != mother_folder_timestamp → process."""
+        folders_to_check, updated_folders, mock_inst = self._run(
+            FolderForDecompose(mother_folder_num='789', mother_folder_timestamp='ts_new'),
+            {'789': 'ts_old'},
+        )
+        mock_inst.decompose_folder.assert_called_once()
+
+    def test_saves_timestamp_after_process(self):
+        """After processing, folder_timestamps gets the folder's timestamp."""
+        ts: dict = {}
+        self._run(
+            FolderForDecompose(mother_folder_num='111', mother_folder_timestamp='ts_new'),
+            ts,
+        )
+        assert ts.get('111') == 'ts_new'
+
+    def test_queues_subfolders_with_timestamps(self):
+        folder = FolderForDecompose(mother_folder_num='555', mother_folder_timestamp='ts_parent')
+        children = [
+            Subfolder(folder_num=111, change_time_str='child_ts1'),
+            Subfolder(folder_num=222, change_time_str='child_ts2'),
+        ]
+        folders_to_check, *_ = self._run(folder, child_subfolders=children)
+        assert folders_to_check[0].mother_folder_num == '111'
+        assert folders_to_check[0].mother_folder_timestamp == 'child_ts1'
+        assert folders_to_check[1].mother_folder_num == '222'
+        assert folders_to_check[1].mother_folder_timestamp == 'child_ts2'
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# save_root_timestamps — unit tests with mocked storage
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSaveRootTimestamps:
+    """save_root_timestamps reads current dict, adds new entries, writes back."""
+
+    def test_adds_new_timestamps(self):
+        with patch.object(KeyValueStorage, 'read_foder_root_modified_times_dict', return_value={'1': 'old_ts'}):
+            with patch.object(KeyValueStorage, 'write_foder_root_modified_times_dict') as mock_write:
+                save_root_timestamps([('2', 'new_ts')])
+
+        mock_write.assert_called_once_with({'1': 'old_ts', '2': 'new_ts'})
+
+    def test_empty_list_returns_early(self):
+        """Empty list → early return, no DB calls at all."""
+        with patch.object(KeyValueStorage, 'read_foder_root_modified_times_dict') as mock_read:
+            with patch.object(KeyValueStorage, 'write_foder_root_modified_times_dict') as mock_write:
+                save_root_timestamps([])
+
+        mock_read.assert_not_called()
+        mock_write.assert_not_called()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# get_updated_root_folders — unit tests with mocked forum + storage
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGetUpdatedRootFolders:
+    """Should return changed root folders WITHOUT saving timestamps."""
+
+    def _mock_storage(self, saved: dict | None = None):
+        return patch.object(
+            KeyValueStorage,
+            'read_foder_root_modified_times_dict',
+            return_value=saved if saved else {},
+        )
+
+    def test_returns_only_changed_folder(self):
+        """Only folders with changed timestamps are returned."""
+        saved = {'1': '2024-01-01T00:00:00+00:00', '2': '2024-01-01T00:00:00+00:00'}
+        with patch.object(
+            FolderUpdateChecker,
+            'check_updates_in_folder_with_folders',
+            return_value=[
+                ['1', '2024-01-01T00:00:00+00:00', datetime.datetime(2024, 1, 1)],
+                ['2', '2025-06-01T00:00:00+00:00', datetime.datetime(2025, 6, 1)],
+            ],
+        ):
+            with self._mock_storage(saved):
+                result = get_updated_root_folders()
+
+        assert result == [('2', '2025-06-01T00:00:00+00:00')]
+
+    def test_does_not_write_storage(self):
+        """get_updated_root_folders should NOT write timestamps."""
+        with patch.object(
+            FolderUpdateChecker,
+            'check_updates_in_folder_with_folders',
+            return_value=[
+                ['1', 'new_ts', datetime.datetime(2025, 1, 1)],
+            ],
+        ):
+            with self._mock_storage({'1': '2024-01-01T00:00:00+00:00'}):
+                with patch.object(KeyValueStorage, 'write_foder_root_modified_times_dict') as mock_write:
+                    get_updated_root_folders()
+
+        mock_write.assert_not_called()
+
+    def test_empty_when_no_updates(self):
+        with patch.object(
+            FolderUpdateChecker,
+            'check_updates_in_folder_with_folders',
+            return_value=[['1', '2024-01-01T00:00:00+00:00', datetime.datetime(2024, 1, 1)]],
+        ):
+            with self._mock_storage({'1': '2024-01-01T00:00:00+00:00'}):
+                assert get_updated_root_folders() == []
+
+    def test_new_folder_detected(self):
+        saved = {'1': '2024-01-01T00:00:00+00:00'}
+        with patch.object(
+            FolderUpdateChecker,
+            'check_updates_in_folder_with_folders',
+            return_value=[
+                ['1', '2024-01-01T00:00:00+00:00', datetime.datetime(2024, 1, 1)],
+                ['2', '2025-06-01T00:00:00+00:00', datetime.datetime(2025, 6, 1)],
+            ],
+        ):
+            with self._mock_storage(saved):
+                assert get_updated_root_folders() == [('2', '2025-06-01T00:00:00+00:00')]
+
+    def test_empty_when_forum_unavailable(self):
+        with patch.object(FolderUpdateChecker, 'check_updates_in_folder_with_folders', return_value=[]):
+            assert get_updated_root_folders() == []
+
+    def test_empty_when_no_saved_data_and_no_forum_data(self):
+        with patch.object(FolderUpdateChecker, 'check_updates_in_folder_with_folders', return_value=[]):
+            assert get_updated_root_folders() == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# main() — integration: saves roots only on success
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMainRootTimestampSave:
+    """main() should save root timestamps only after successful traversal."""
+
+    @patch('check_topics_by_upd_time._legacy.main.get_updated_root_folders')
+    @patch('check_topics_by_upd_time._legacy.main.get_updates_of_nested_folders')
+    @patch('check_topics_by_upd_time._legacy.main.pubsub_parse_folders')
+    @patch('check_topics_by_upd_time._legacy.main.save_root_timestamps')
+    def test_saves_on_success(
+        self,
+        mock_save,
+        mock_pubsub,
+        mock_get_updates,
+        mock_get_roots,
+    ):
+        mock_get_roots.return_value = [('1', 'ts1')]
+        mock_get_updates.return_value = []
+
+        from check_topics_by_upd_time._legacy.main import main as legacy_main
+
+        legacy_main({}, None)
+
+        mock_save.assert_called_once_with([('1', 'ts1')])
+
+    @patch('check_topics_by_upd_time._legacy.main.get_updated_root_folders')
+    @patch('check_topics_by_upd_time._legacy.main.get_updates_of_nested_folders')
+    @patch('check_topics_by_upd_time._legacy.main.pubsub_parse_folders')
+    @patch('check_topics_by_upd_time._legacy.main.save_root_timestamps')
+    def test_does_not_save_on_failure(
+        self,
+        mock_save,
+        mock_pubsub,
+        mock_get_updates,
+        mock_get_roots,
+    ):
+        mock_get_roots.return_value = [('1', 'ts1')]
+        mock_get_updates.side_effect = RuntimeError('traversal failed')
+
+        from check_topics_by_upd_time._legacy.main import main as legacy_main
+
+        with pytest.raises(RuntimeError):
+            legacy_main({}, None)
+
+        mock_save.assert_not_called()
+
+    @patch('check_topics_by_upd_time._legacy.main.get_updated_root_folders')
+    @patch('check_topics_by_upd_time._legacy.main.get_updates_of_nested_folders')
+    @patch('check_topics_by_upd_time._legacy.main.pubsub_parse_folders')
+    @patch('check_topics_by_upd_time._legacy.main.save_root_timestamps')
+    def test_early_return_when_no_roots(
+        self,
+        mock_save,
+        mock_pubsub,
+        mock_get_updates,
+        mock_get_roots,
+    ):
+        mock_get_roots.return_value = []
+
+        from check_topics_by_upd_time._legacy.main import main as legacy_main
+
+        legacy_main({}, None)
+
+        mock_get_updates.assert_not_called()
+        mock_pubsub.assert_not_called()
+        mock_save.assert_not_called()
+
+    @patch('check_topics_by_upd_time._legacy.main.get_updated_root_folders')
+    @patch('check_topics_by_upd_time._legacy.main.get_updates_of_nested_folders')
+    @patch('check_topics_by_upd_time._legacy.main.pubsub_parse_folders')
+    def test_pubsub_called_with_updated_folders(
+        self,
+        mock_pubsub,
+        mock_get_updates,
+        mock_get_roots,
+    ):
+        mock_get_roots.return_value = [('1', 'ts1')]
+        mock_get_updates.return_value = [('1', 'folder1')]
+
+        from check_topics_by_upd_time._legacy.main import main as legacy_main
+
+        legacy_main({}, None)
+
+        mock_pubsub.assert_called_once_with([('1', 'folder1')])
+
+    @patch('check_topics_by_upd_time._legacy.main.get_updated_root_folders')
+    @patch('check_topics_by_upd_time._legacy.main.get_updates_of_nested_folders')
+    @patch('check_topics_by_upd_time._legacy.main.pubsub_parse_folders')
+    def test_pubsub_not_called_when_empty(
+        self,
+        mock_pubsub,
+        mock_get_updates,
+        mock_get_roots,
+    ):
+        mock_get_roots.return_value = [('1', 'ts1')]
+        mock_get_updates.return_value = []
+
+        from check_topics_by_upd_time._legacy.main import main as legacy_main
+
+        legacy_main({}, None)
+
+        mock_pubsub.assert_not_called()


### PR DESCRIPTION
…pd_time

- Added FOLDER_TIMESTAMPS_KEY to KeyValueStorage for per-folder timestamps (read/write via folder_timestamps dict in DB)
- FolderForDecompose now carries mother_folder_timestamp from parent
- process_folder skips HTTP fetch + parse if the folder's timestamp hasn't changed since last successful check
- Root timestamps are saved ONLY after full tree traversal succeeds, fixing a bug where a crash mid-traversal permanently skipped roots
- Refactored get_the_list_folders_to_update into get_updated_root_folders (returns tuples with timestamps) + save_root_timestamps (delayed save)

This avoids redundant forum page fetches on repeated runs and prevents root timestamps from being persisted before child folders are processed.

test: add unit tests for _legacy/main.py — FolderComparator, timestamp skip, root save

- FolderComparator: pure unit tests (new, changed, removed, mixed)
- process_folder timestamp skip: saved ts matches → skip, mismatch → process
- save_root_timestamps: verifies read-merge-write cycle
- get_updated_root_folders: returns changed roots without saving
- main(): saves root timestamps only on success, not on failure
- All tests use mocks for DB/HTTP to stay fast and isolated

