### PR TITLE
log_inspector now uses  yandexcloud SDK (gRPC)

### DIFF
--- a/tests/test_log_inspector/test_yc_logging.py
+++ b/tests/test_log_inspector/test_yc_logging.py
@@ -1,14 +1,21 @@
-"""Tests for YC Log Inspector — YC Logging API client."""
+"""Tests for YC Log Inspector — gRPC-based YC Logging client."""
 
 import json
 from datetime import datetime, timezone
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from google.protobuf.timestamp_pb2 import Timestamp
+from yandex.cloud.logging.v1.log_entry_pb2 import LogEntry, LogLevel
+from yandex.cloud.logging.v1.log_group_service_pb2 import (
+    ListLogGroupsRequest,
+)
+from yandex.cloud.logging.v1.log_group_service_pb2_grpc import LogGroupServiceStub
+from yandex.cloud.logging.v1.log_reading_service_pb2_grpc import LogReadingServiceStub
 
 from tools.log_inspector._utils.yc_logging import (
     AuthError,
-    IamTokenAuth,
+    LogGroup,
     YCLoggingClient,
 )
 
@@ -49,193 +56,261 @@ SERVICE_ACCOUNT_KEY = {
 
 
 # ---------------------------------------------------------------------------
-# IamTokenAuth
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-class TestIamTokenAuth:
-    def test_uses_sa_json_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv('YC_SERVICE_ACCOUNT_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+def _make_mock_sdk() -> MagicMock:
+    """Create a mock SDK with mock gRPC stubs."""
+    sdk = MagicMock()
+    sdk.client = MagicMock()
+    return sdk
 
-        mock_resp = Mock()
-        mock_resp.raise_for_status = Mock()
-        mock_resp.json.return_value = {
-            'iamToken': 't1.sa...xyz',
-            'expiresAt': '2099-01-01T00:00:00Z',
-        }
 
-        with (
-            patch.object(IamTokenAuth, '_make_jwt', return_value='mock-jwt-token') as mock_jwt,
-            patch('httpx.post', return_value=mock_resp) as mock_post,
-        ):
-            auth = IamTokenAuth()
-            token = auth.get_token()
-            assert token == 't1.sa...xyz'
-            mock_jwt.assert_called_once()
-            mock_post.assert_called_once()
+def _make_entry(uid: str, level: int, message: str, timestamp: datetime) -> MagicMock:
+    """Create a mock LogEntry-like object."""
+    entry = MagicMock(spec=LogEntry)
+    entry.uid = uid
+    entry.level = level
+    entry.message = message
 
-    def test_caches_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv('YC_SERVICE_ACCOUNT_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+    ts_proto = Timestamp()
+    ts_proto.FromDatetime(timestamp)
+    entry.timestamp = ts_proto
 
-        mock_resp = Mock()
-        mock_resp.raise_for_status = Mock()
-        mock_resp.json.return_value = {'iamToken': 't1.sa...xyz'}
+    entry.stream_name = ''
+    entry.HasField.return_value = False
+    entry.json_payload = None
+    return entry
 
-        with (
-            patch('httpx.post', return_value=mock_resp) as mock_post,
-            patch.object(IamTokenAuth, '_make_jwt', return_value='mock-jwt'),
-        ):
-            auth = IamTokenAuth()
-            auth.get_token()
-            assert mock_post.call_count == 1
 
-            # Second call should use cache
-            auth.get_token()
-            assert mock_post.call_count == 1
+def _make_log_group(id_: str, name: str, folder_id: str) -> MagicMock:
+    """Create a mock log group protobuf message."""
+    g = MagicMock()
+    g.id = id_
+    g.name = name
+    g.folder_id = folder_id
+    return g
 
+
+# ---------------------------------------------------------------------------
+# YCLoggingClient — Auth
+# ---------------------------------------------------------------------------
+
+
+class TestYCLoggingClientAuth:
     def test_fails_without_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv('YC_SERVICE_ACCOUNT_JSON', raising=False)
-        with pytest.raises(AuthError, match='YC_SERVICE_ACCOUNT_JSON'):
-            IamTokenAuth().get_token()
+        monkeypatch.delenv('YC_LOG_INSPECTOR_SA_JSON', raising=False)
+        with pytest.raises(AuthError, match='YC_LOG_INSPECTOR_SA_JSON'):
+            YCLoggingClient()
 
-    def test_invalidate_clears_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv('YC_SERVICE_ACCOUNT_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+    def test_uses_sa_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('YC_LOG_INSPECTOR_SA_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
 
-        mock_resp = Mock()
-        mock_resp.raise_for_status = Mock()
-        mock_resp.json.return_value = {'iamToken': 't1.sa...xyz'}
-
-        with (
-            patch('httpx.post', return_value=mock_resp) as mock_post,
-            patch.object(IamTokenAuth, '_make_jwt', return_value='mock-jwt'),
-        ):
-            auth = IamTokenAuth()
-            auth.get_token()
-            assert mock_post.call_count == 1
-
-            auth.invalidate()
-            auth.get_token()
-            assert mock_post.call_count == 2
+        with patch('tools.log_inspector._utils.yc_logging.SDK') as mock_sdk_cls:
+            client = YCLoggingClient()
+            mock_sdk_cls.assert_called_once_with(service_account_key=SERVICE_ACCOUNT_KEY)
+            assert client._sdk is not None
 
 
 # ---------------------------------------------------------------------------
-# YCLoggingClient
+# YCLoggingClient — Log Groups
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def client() -> YCLoggingClient:
-    """Return a client with a mocked auth that always returns 'test-token'."""
-    auth = Mock(spec=IamTokenAuth)
-    auth.get_token.return_value = 'test-token'
-    return YCLoggingClient(auth=auth)
+class TestListLogGroups:
+    def test_lists_groups(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('YC_LOG_INSPECTOR_SA_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
 
+        mock_sdk = _make_mock_sdk()
+        mock_stub = MagicMock()
+        mock_group_1 = _make_log_group('lg-001', 'bot-logs', 'fc-test')
+        mock_group_2 = _make_log_group('lg-002', 'api-logs', 'fc-test')
 
-def _mock_response(json_data: dict, status: int = 200) -> Mock:
-    """Build a mock HTTP response."""
-    resp = Mock()
-    resp.status_code = status
-    resp.raise_for_status = Mock()
-    resp.json.return_value = json_data
-    return resp
+        resp = MagicMock()
+        resp.groups = [mock_group_1, mock_group_2]
+        mock_stub.List.return_value = resp
 
+        def client_side_effect(stub_cls):
+            if stub_cls == LogGroupServiceStub:
+                return mock_stub
+            return MagicMock()
 
-class TestYCLoggingClient:
-    def test_list_log_groups(self, client: YCLoggingClient) -> None:
-        mock_resp = _mock_response(
-            {
-                'groups': [
-                    {'id': 'lg-001', 'name': 'bot-logs', 'folderId': 'fc-test'},
-                    {'id': 'lg-002', 'name': 'api-logs', 'folderId': 'fc-test'},
-                ],
-            }
-        )
+        mock_sdk.client.side_effect = client_side_effect
 
-        with patch.object(client._http, 'request', return_value=mock_resp) as mock_request:
+        with patch('tools.log_inspector._utils.yc_logging.SDK', return_value=mock_sdk):
+            client = YCLoggingClient()
             groups = client.list_log_groups('fc-test')
-            assert len(groups) == 2
-            assert groups[0].id == 'lg-001'
-            assert groups[0].name == 'bot-logs'
-            mock_request.assert_called_once()
 
-    def test_read_single_page(self, client: YCLoggingClient) -> None:
-        mock_resp = _mock_response(
-            {
-                'entries': [
-                    {
-                        'uid': '1',
-                        'level': 'ERROR',
-                        'message': 'something broke',
-                        'timestamp': '2026-07-04T18:00:00Z',
-                    },
-                ],
-                'next_page_token': 'page2',
-            }
-        )
+        assert len(groups) == 2
+        assert groups[0] == LogGroup(id='lg-001', name='bot-logs', folder_id='fc-test')
+        assert groups[1] == LogGroup(id='lg-002', name='api-logs', folder_id='fc-test')
+        mock_stub.List.assert_called_once_with(ListLogGroupsRequest(folder_id='fc-test'))
 
-        with patch.object(client._http, 'request', return_value=mock_resp) as mock_request:
+
+# ---------------------------------------------------------------------------
+# YCLoggingClient — Read Logs
+# ---------------------------------------------------------------------------
+
+
+class TestReadLogs:
+    def test_read_single_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('YC_LOG_INSPECTOR_SA_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+
+        mock_sdk = _make_mock_sdk()
+        mock_reading_stub = MagicMock()
+        mock_group_stub = MagicMock()
+
+        now = datetime(2026, 7, 4, 18, 0, 0, tzinfo=timezone.utc)
+        entry = _make_entry('uid-1', LogLevel.ERROR, 'something broke', now)
+
+        read_resp = MagicMock()
+        read_resp.entries = [entry]
+        read_resp.next_page_token = 'page2'
+        mock_reading_stub.Read.return_value = read_resp
+
+        def client_side_effect(stub_cls):
+            if stub_cls == LogGroupServiceStub:
+                return mock_group_stub
+            if stub_cls == LogReadingServiceStub:
+                return mock_reading_stub
+            return MagicMock()
+
+        mock_sdk.client.side_effect = client_side_effect
+
+        with patch('tools.log_inspector._utils.yc_logging.SDK', return_value=mock_sdk):
+            client = YCLoggingClient()
             result = client.read_logs('lg-xxx', levels=['ERROR'])
-            assert len(result['entries']) == 1
-            assert result['next_page_token'] == 'page2'
-            mock_request.assert_called_once()
 
-    def test_read_all_logs_paginates(self, client: YCLoggingClient) -> None:
-        page_1_resp = _mock_response(
-            {
-                'entries': [
-                    {'uid': '1', 'level': 'ERROR', 'message': 'err1', 'timestamp': 't1'},
-                ],
-                'next_page_token': 'p2',
-            }
-        )
-        page_2_resp = _mock_response(
-            {
-                'entries': [
-                    {'uid': '2', 'level': 'ERROR', 'message': 'err2', 'timestamp': 't2'},
-                ],
-            }
-        )
+        assert len(result['entries']) == 1
+        assert result['next_page_token'] == 'page2'
+        assert result['entries'][0]['uid'] == 'uid-1'
+        assert result['entries'][0]['level'] == 'ERROR'
+        assert result['entries'][0]['message'] == 'something broke'
 
-        with patch.object(client._http, 'request', side_effect=[page_1_resp, page_2_resp]):
+    def test_read_all_logs_paginates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('YC_LOG_INSPECTOR_SA_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+
+        mock_sdk = _make_mock_sdk()
+        mock_reading_stub = MagicMock()
+        mock_group_stub = MagicMock()
+
+        now = datetime(2026, 7, 4, 18, 0, 0, tzinfo=timezone.utc)
+
+        resp_1 = MagicMock()
+        resp_1.entries = [_make_entry('uid-1', LogLevel.ERROR, 'err1', now)]
+        resp_1.next_page_token = 'p2'
+
+        resp_2 = MagicMock()
+        resp_2.entries = [_make_entry('uid-2', LogLevel.ERROR, 'err2', now)]
+        resp_2.next_page_token = ''
+
+        mock_reading_stub.Read.side_effect = [resp_1, resp_2]
+
+        def client_side_effect(stub_cls):
+            if stub_cls == LogGroupServiceStub:
+                return mock_group_stub
+            if stub_cls == LogReadingServiceStub:
+                return mock_reading_stub
+            return MagicMock()
+
+        mock_sdk.client.side_effect = client_side_effect
+
+        with patch('tools.log_inspector._utils.yc_logging.SDK', return_value=mock_sdk):
+            client = YCLoggingClient()
             entries = client.read_all_logs('lg-xxx')
-            assert len(entries) == 2
 
-    def test_read_all_logs_respects_max_pages(self, client: YCLoggingClient) -> None:
-        page_resp = _mock_response(
-            {
-                'entries': [
-                    {'uid': '1', 'level': 'INFO', 'message': 'msg', 'timestamp': 't'},
-                ],
-                'next_page_token': 'still-more',
-            }
-        )
+        assert len(entries) == 2
 
-        with patch.object(client._http, 'request', return_value=page_resp):
+    def test_read_all_logs_respects_max_pages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('YC_LOG_INSPECTOR_SA_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+
+        mock_sdk = _make_mock_sdk()
+        mock_reading_stub = MagicMock()
+        mock_group_stub = MagicMock()
+
+        now = datetime(2026, 7, 4, 18, 0, 0, tzinfo=timezone.utc)
+
+        resp = MagicMock()
+        resp.entries = [_make_entry('uid-1', LogLevel.INFO, 'msg', now)]
+        resp.next_page_token = 'still-more'
+
+        mock_reading_stub.Read.return_value = resp
+
+        def client_side_effect(stub_cls):
+            if stub_cls == LogGroupServiceStub:
+                return mock_group_stub
+            if stub_cls == LogReadingServiceStub:
+                return mock_reading_stub
+            return MagicMock()
+
+        mock_sdk.client.side_effect = client_side_effect
+
+        with patch('tools.log_inspector._utils.yc_logging.SDK', return_value=mock_sdk):
+            client = YCLoggingClient()
             entries = client.read_all_logs('lg-xxx', max_pages=2)
-            assert len(entries) == 2
 
-    def test_passes_time_range(self, client: YCLoggingClient) -> None:
+        assert len(entries) == 2
+
+    def test_passes_time_range(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('YC_LOG_INSPECTOR_SA_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+
+        mock_sdk = _make_mock_sdk()
+        mock_reading_stub = MagicMock()
+        mock_group_stub = MagicMock()
+
         from_time = datetime(2026, 7, 4, 0, 0, 0, tzinfo=timezone.utc)
-        mock_resp = _mock_response({'entries': []})
 
-        with patch.object(client._http, 'request', return_value=mock_resp) as mock_request:
+        resp = MagicMock()
+        resp.entries = []
+        resp.next_page_token = ''
+        mock_reading_stub.Read.return_value = resp
+
+        def client_side_effect(stub_cls):
+            if stub_cls == LogGroupServiceStub:
+                return mock_group_stub
+            if stub_cls == LogReadingServiceStub:
+                return mock_reading_stub
+            return MagicMock()
+
+        mock_sdk.client.side_effect = client_side_effect
+
+        with patch('tools.log_inspector._utils.yc_logging.SDK', return_value=mock_sdk):
+            client = YCLoggingClient()
             client.read_logs('lg-x', from_time=from_time)
-            call_args = mock_request.call_args
-            body = call_args[1]['json']
-            assert body['from'] == '2026-07-04T00:00:00Z'
 
-    def test_retries_on_401(self, client: YCLoggingClient) -> None:
-        """Should refresh token on 401 and retry the request once."""
-        fail_resp = _mock_response({'error': 'unauthorized'}, status=401)
-        ok_resp = _mock_response(
-            {
-                'entries': [
-                    {'uid': '1', 'level': 'ERROR', 'message': 'ok after retry', 'timestamp': 't1'},
-                ],
-            }
-        )
+        call_args = mock_reading_stub.Read.call_args
+        request = call_args[0][0]
+        assert request.HasField('criteria')
+        # Proto Timestamp.ToDatetime() returns naive UTC
+        assert request.criteria.since.ToDatetime() == from_time.replace(tzinfo=None)
 
-        with patch.object(client._http, 'request', side_effect=[fail_resp, ok_resp]):
-            result = client.read_logs('lg-x', levels=['ERROR'])
-            assert len(result['entries']) == 1
-            assert result['entries'][0]['message'] == 'ok after retry'
+    def test_uses_page_token_when_provided(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('YC_LOG_INSPECTOR_SA_JSON', json.dumps(SERVICE_ACCOUNT_KEY))
+
+        mock_sdk = _make_mock_sdk()
+        mock_reading_stub = MagicMock()
+        mock_group_stub = MagicMock()
+
+        resp = MagicMock()
+        resp.entries = []
+        resp.next_page_token = ''
+        mock_reading_stub.Read.return_value = resp
+
+        def client_side_effect(stub_cls):
+            if stub_cls == LogGroupServiceStub:
+                return mock_group_stub
+            if stub_cls == LogReadingServiceStub:
+                return mock_reading_stub
+            return MagicMock()
+
+        mock_sdk.client.side_effect = client_side_effect
+
+        with patch('tools.log_inspector._utils.yc_logging.SDK', return_value=mock_sdk):
+            client = YCLoggingClient()
+            client.read_logs('lg-x', page_token='next-page')
+
+        call_args = mock_reading_stub.Read.call_args
+        request = call_args[0][0]
+        assert request.page_token == 'next-page'
+        assert not request.HasField('criteria')

--- a/tools/log_inspector/_utils/yc_logging.py
+++ b/tools/log_inspector/_utils/yc_logging.py
@@ -1,84 +1,43 @@
-"""YC Logging REST API client.
+"""YC Logging gRPC client via yandexcloud SDK.
 
-Uses YC_SERVICE_ACCOUNT_JSON environment variable for authentication.
+Uses YC_LOG_INSPECTOR_SA_JSON environment variable for authentication.
 """
 
 import json
 import logging
 import os
-import time
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 from typing import Any
 
-import httpx
-import jwt
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.timestamp_pb2 import Timestamp  # type: ignore[attr-defined]
+from yandex.cloud.logging.v1.log_entry_pb2 import LogLevel
+from yandex.cloud.logging.v1.log_group_service_pb2 import ListLogGroupsRequest
+from yandex.cloud.logging.v1.log_group_service_pb2_grpc import LogGroupServiceStub
+from yandex.cloud.logging.v1.log_reading_service_pb2 import Criteria, ReadRequest
+from yandex.cloud.logging.v1.log_reading_service_pb2_grpc import LogReadingServiceStub
+from yandexcloud import SDK
 
 logger = logging.getLogger(__name__)
 
-YC_IAM_TOKEN_URL = 'https://iam.api.cloud.yandex.net/iam/v1/tokens'
-YC_LOGGING_BASE_URL = 'https://api.logging.yandexcloud.net/logging/v1'
+_ENV_VAR = 'YC_LOG_INSPECTOR_SA_JSON'
+
+# Map REST-style level names to protobuf enums
+_LEVEL_TO_PROTO: dict[str, int] = {
+    'TRACE': LogLevel.TRACE,
+    'DEBUG': LogLevel.DEBUG,
+    'INFO': LogLevel.INFO,
+    'WARN': LogLevel.WARN,
+    'WARNING': LogLevel.WARN,
+    'ERROR': LogLevel.ERROR,
+    'CRITICAL': LogLevel.FATAL,
+    'FATAL': LogLevel.FATAL,
+}
 
 
 class AuthError(RuntimeError):
     """Authentication-related errors."""
-
-
-class IamTokenAuth:
-    """Provides an IAM token from the YC_SERVICE_ACCOUNT_JSON environment variable.
-
-    Exchanges the service account key for an IAM token via the YC IAM API.
-    Caches the token and handles refresh on expiry.
-    """
-
-    def __init__(self) -> None:
-        self._token: str | None = None
-        self._expiry: datetime | None = None
-
-    def get_token(self) -> str:
-        """Return a valid IAM token, exchanging SA key if needed."""
-        if self._token and self._expiry and datetime.now(timezone.utc) < self._expiry:
-            return self._token
-
-        sa_json = os.environ.get('YC_SERVICE_ACCOUNT_JSON')
-        if not sa_json:
-            raise AuthError(
-                'YC_SERVICE_ACCOUNT_JSON environment variable is not set. '
-                'Create a service account key via YC CLI:\n'
-                '  yc iam key create --service-account-name <name> --output key.json\n'
-                'Then set YC_SERVICE_ACCOUNT_JSON to the contents of key.json'
-            )
-
-        self._token = self._exchange_sa_key(sa_json)
-        # IAM tokens are valid for 12h, refresh after 11h
-        self._expiry = datetime.now(timezone.utc) + timedelta(hours=11)
-        return self._token
-
-    @staticmethod
-    def _make_jwt(sa_key: dict) -> str:
-        """Create a signed JWT using a Yandex Cloud service account key."""
-        now = int(time.time())
-        payload = {
-            'aud': YC_IAM_TOKEN_URL,
-            'iss': sa_key['service_account_id'],
-            'iat': now,
-            'exp': now + 3600,
-        }
-        headers = {'kid': sa_key['id'], 'typ': 'JWT'}
-        return jwt.encode(payload, sa_key['private_key'], algorithm='PS256', headers=headers)
-
-    def _exchange_sa_key(self, sa_json_str: str) -> str:
-        """Exchange service account key JSON for an IAM token."""
-        sa_key = json.loads(sa_json_str)
-        jwt_token = self._make_jwt(sa_key)
-        resp = httpx.post(YC_IAM_TOKEN_URL, json={'jwt': jwt_token}, timeout=10)
-        resp.raise_for_status()
-        return resp.json()['iamToken']
-
-    def invalidate(self) -> None:
-        """Force token refresh on next call."""
-        self._token = None
-        self._expiry = None
 
 
 @dataclass
@@ -88,57 +47,53 @@ class LogGroup:
     folder_id: str
 
 
-class YCLoggingClient:
-    """YC Logging REST API client.
+def _make_sdk() -> SDK:
+    """Create and return an authenticated yandexcloud SDK instance."""
+    sa_json = os.environ.get(_ENV_VAR)
+    if not sa_json:
+        raise AuthError(
+            f'{_ENV_VAR} environment variable is not set. '
+            'Create a service account key via YC CLI:\n'
+            '  yc iam key create --service-account-name <name> --output key.json\n'
+            f'Then set {_ENV_VAR} to the contents of key.json'
+        )
+    return SDK(service_account_key=json.loads(sa_json))
 
-    Uses IamTokenAuth for authentication via the YC_SERVICE_ACCOUNT_JSON env var.
+
+def _entry_to_dict(entry: Any) -> dict[str, Any]:
+    """Convert a protobuf LogEntry to a plain dict compatible with analytics."""
+    d: dict[str, Any] = {
+        'uid': entry.uid,
+        'level': LogLevel.Level.Name(entry.level),
+        'message': entry.message,
+        'timestamp': entry.timestamp.ToDatetime().isoformat(),
+        'stream_name': entry.stream_name,
+    }
+    if entry.HasField('json_payload') and entry.json_payload:
+        d['json_payload'] = MessageToDict(entry.json_payload)
+    return d
+
+
+class YCLoggingClient:
+    """YC Logging gRPC client using yandexcloud SDK.
+
+    Uses YC_LOG_INSPECTOR_SA_JSON for service account auth.
     """
 
-    def __init__(self, auth: IamTokenAuth | None = None) -> None:
-        self._auth = auth or IamTokenAuth()
-        self._http = httpx.Client(timeout=30.0)
+    def __init__(self) -> None:
+        self._sdk = _make_sdk()
+        self._log_group_stub = self._sdk.client(LogGroupServiceStub)
+        self._log_reading_stub = self._sdk.client(LogReadingServiceStub)
 
-    # ── Internal HTTP ───────────────────────────────────────────────
-
-    def _ensure_headers(self) -> dict[str, str]:
-        """Return auth headers, fetching/refreshing token as needed."""
-        token = self._auth.get_token()
-        return {'Authorization': f'Bearer {token}'}
-
-    def _request(self, method: str, url: str, **kwargs: Any) -> Any:
-        """Make an authenticated request with automatic token refresh on 401."""
-        headers = self._ensure_headers()
-        headers.update(kwargs.pop('headers', {}))
-
-        resp = self._http.request(method, url, headers=headers, **kwargs)
-
-        if resp.status_code == 401:
-            # Token expired, force refresh and retry once
-            self._auth.invalidate()
-            headers = self._ensure_headers()
-            headers.update(kwargs.pop('headers', {}))
-            resp = self._http.request(method, url, headers=headers, **kwargs)
-
-        resp.raise_for_status()
-        return resp.json()
-
-    # ── API Methods ─────────────────────────────────────────────────
+    # ── Log Groups ───────────────────────────────────────────────────
 
     def list_log_groups(self, folder_id: str) -> list[LogGroup]:
         """List available log groups in a YC folder."""
-        data = self._request(
-            'GET',
-            f'{YC_LOGGING_BASE_URL}/logGroups',
-            params={'folderId': folder_id},
-        )
-        return [
-            LogGroup(
-                id=g['id'],
-                name=g.get('name', ''),
-                folder_id=g.get('folderId', ''),
-            )
-            for g in data.get('groups', [])
-        ]
+        request = ListLogGroupsRequest(folder_id=folder_id)
+        response = self._log_group_stub.List(request)
+        return [LogGroup(id=g.id, name=g.name, folder_id=g.folder_id) for g in response.groups]
+
+    # ── Read Logs ────────────────────────────────────────────────────
 
     def read_logs(
         self,
@@ -155,28 +110,40 @@ class YCLoggingClient:
 
         Returns dict with 'entries' and optional 'next_page_token'.
         """
-        body: dict[str, Any] = {'page_size': page_size}
-
-        criteria: dict[str, Any] = {}
-        if levels:
-            criteria['levels'] = levels
-        if filter_str:
-            criteria['filter'] = filter_str
-        if criteria:
-            body['criteria'] = criteria
-
-        if from_time:
-            body['from'] = from_time.strftime('%Y-%m-%dT%H:%M:%SZ')
-        if to_time:
-            body['to'] = to_time.strftime('%Y-%m-%dT%H:%M:%SZ')
         if page_token:
-            body['page_token'] = page_token
+            request = ReadRequest(page_token=page_token)
+        else:
+            criteria = Criteria(log_group_id=log_group_id, page_size=page_size)
 
-        return self._request(
-            'POST',
-            f'{YC_LOGGING_BASE_URL}/logGroupId/{log_group_id}/entries:read',
-            json=body,
-        )
+            if levels:
+                proto_levels = []
+                for lvl in levels:
+                    enum_val = _LEVEL_TO_PROTO.get(lvl.upper())
+                    if enum_val is not None:
+                        proto_levels.append(enum_val)
+                criteria.levels.extend(proto_levels)  # type: ignore[arg-type]
+
+            if filter_str:
+                criteria.filter = filter_str
+
+            if from_time:
+                ts = Timestamp()
+                ts.FromDatetime(from_time)
+                criteria.since.CopyFrom(ts)
+
+            if to_time:
+                ts = Timestamp()
+                ts.FromDatetime(to_time)
+                criteria.until.CopyFrom(ts)
+
+            request = ReadRequest(criteria=criteria)
+
+        response = self._log_reading_stub.Read(request)
+
+        return {
+            'entries': [_entry_to_dict(e) for e in response.entries],
+            'next_page_token': response.next_page_token or None,
+        }
 
     def read_all_logs(
         self,
@@ -213,5 +180,4 @@ class YCLoggingClient:
         return entries
 
     def close(self) -> None:
-        """Close the underlying HTTP client."""
-        self._http.close()
+        """No-op for compatibility; gRPC channels managed by SDK."""

--- a/tools/log_inspector/main.py
+++ b/tools/log_inspector/main.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """YC Log Inspector — Yandex Cloud Logging error investigation tool.
 
+Uses yandexcloud SDK (gRPC) instead of REST API.
+
 Ref: https://github.com/volodkindv/la_searcher_bot/issues/4
 Ref: https://github.com/volodkindv/la_searcher_bot/issues/5
 
@@ -11,7 +13,7 @@ Modes:
   raw          Raw JSON dump for programmatic use.
 
 Auth:
-  YC_SERVICE_ACCOUNT_JSON env var (service account key file)
+  YC_LOG_INSPECTOR_SA_JSON env var (service account key JSON)
 
 Usage:
   uv run python tools/log_inspector/main.py top-errors <log-group-id> --hours 24 --top 10


### PR DESCRIPTION
- yc_logging.py: REST API (httpx) → gRPC (yandexcloud SDK)
- fix  env var name: YC_SERVICE_ACCOUNT_JSON → YC_LOG_INSPECTOR_SA_JSON

Closes #4, #5