### PR TITLE
fix: safe rollback in compose_notifications & send_notifications main()

### DIFF
--- a/src/compose_notifications/main.py
+++ b/src/compose_notifications/main.py
@@ -161,12 +161,14 @@ def main(event: dict, context: Ctx) -> None:
             call_self_if_need_compose_more(conn, function_id)
         conn.commit()
     except FunctionLockError:
-        conn.rollback()
         logging.info('function execution stopped due to parallel run with another function')
         logging.info('script cancelled')
         return None
     except:
-        conn.rollback()
+        try:
+            conn.rollback()
+        except Exception:
+            pass
         raise
     finally:
         conn.close()

--- a/src/send_notifications/main.py
+++ b/src/send_notifications/main.py
@@ -663,11 +663,13 @@ def main(event: dict, context: Ctx) -> str | None:
             changed_ids = iterate_over_notifications(function_id, time_analytics)
         connection.commit()
     except FunctionLockError:
-        connection.rollback()
         logging.info('script cancelled')
         return None
     except:
-        connection.rollback()
+        try:
+            connection.rollback()
+        except Exception:
+            pass
         raise
     finally:
         connection.close()


### PR DESCRIPTION
- Remove conn.rollback() from FunctionLockError handler: no transaction was started (lock wasn't acquired), so rollback is unnecessary
- Wrap conn.rollback() in bare except block with try/except to handle cases where the Connection object lacks rollback() (prod mismatch)
- Fixes 100 prod 502 errors in the last 6 hours: AttributeError: 'Connection' object has no attribute 'rollback'