### PR TITLE
fix: use engine.begin() instead of explicit commit/rollback

### DIFF
--- a/src/compose_notifications/main.py
+++ b/src/compose_notifications/main.py
@@ -140,38 +140,30 @@ def main(event: dict, context: Ctx) -> None:
     function_id = generate_random_function_id()
 
     pool = sqlalchemy_get_pool()
-    conn = pool.connect()
-    try:
-        with lock_manager(conn, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
-            # compose New Records List: the delta from Change log
-            new_record = LogRecordComposer(conn).get_line()
-
-            if new_record:
-                list_of_users = UsersListComposer(conn).get_users_list_for_line_in_change_log(new_record)
-                list_of_users = UserListFilter(conn, new_record, list_of_users).apply()
-
-                analytics_iterations_finish = create_user_notifications_from_change_log_record(
-                    analytics_start_of_func,
-                    function_id,
-                    conn,
-                    new_record,
-                    list_of_users,
-                )
-
-            call_self_if_need_compose_more(conn, function_id)
-        conn.commit()
-    except FunctionLockError:
-        logging.info('function execution stopped due to parallel run with another function')
-        logging.info('script cancelled')
-        return None
-    except:
+    with pool.begin() as conn:
         try:
-            conn.rollback()
-        except Exception:
-            pass
-        raise
-    finally:
-        conn.close()
+            with lock_manager(conn, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+                # compose New Records List: the delta from Change log
+                new_record = LogRecordComposer(conn).get_line()
+
+                if new_record:
+                    list_of_users = UsersListComposer(conn).get_users_list_for_line_in_change_log(new_record)
+                    list_of_users = UserListFilter(conn, new_record, list_of_users).apply()
+
+                    analytics_iterations_finish = create_user_notifications_from_change_log_record(
+                        analytics_start_of_func,
+                        function_id,
+                        conn,
+                        new_record,
+                        list_of_users,
+                    )
+
+                call_self_if_need_compose_more(conn, function_id)
+            # engine.begin() auto-commits on success, auto-rollbacks on exception
+        except FunctionLockError:
+            logging.info('function execution stopped due to parallel run with another function')
+            logging.info('script cancelled')
+            return None
 
     analytics_finish = datetime.datetime.now()
     if new_record:

--- a/src/send_notifications/main.py
+++ b/src/send_notifications/main.py
@@ -657,22 +657,14 @@ def main(event: dict, context: Ctx) -> str | None:
     function_id = generate_random_function_id()
 
     pool = sqlalchemy_get_pool()
-    connection = pool.connect()
-    try:
-        with lock_manager(connection, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
-            changed_ids = iterate_over_notifications(function_id, time_analytics)
-        connection.commit()
-    except FunctionLockError:
-        logging.info('script cancelled')
-        return None
-    except:
+    with pool.begin() as connection:
         try:
-            connection.rollback()
-        except Exception:
-            pass
-        raise
-    finally:
-        connection.close()
+            with lock_manager(connection, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+                changed_ids = iterate_over_notifications(function_id, time_analytics)
+            # engine.begin() auto-commits on success, auto-rollbacks on exception
+        except FunctionLockError:
+            logging.info('script cancelled')
+            return None
 
     finish_time_analytics(time_analytics, changed_ids)
 


### PR DESCRIPTION
- Replace pool.connect() + manual commit/rollback/close with pool.begin() context manager which handles transaction lifecycle automatically (BEGIN on enter, COMMIT on success, ROLLBACK on error, CLOSE on exit)
- Fixes AttributeError on prod where Connection object lacks both commit() and rollback() methods
- Code is simpler: no more bare except blocks, no more finally