### PR TITLE
refactor: switch legacy DBClient classes to inherit from DBClientBase

### DIFF
--- a/src/check_first_posts_for_changes/_legacy/_utils/database.py
+++ b/src/check_first_posts_for_changes/_legacy/_utils/database.py
@@ -1,21 +1,15 @@
 import datetime
-from contextlib import _GeneratorContextManager
 from functools import lru_cache
 
 import sqlalchemy
-from sqlalchemy.engine.base import Engine
 
-from _dependencies.common.commons import sqlalchemy_get_pool
+from _dependencies.common.db_client import DBClientBase
 
 from .commons import RSSItem, Search
 
 
-class DBClient:
-    def __init__(self, db: Engine) -> None:
-        self._db = db
-
-    def connect(self) -> _GeneratorContextManager:
-        return self._db.begin()
+class DBClient(DBClientBase):
+    """Legacy DBClient — now inherits from DBClientBase."""
 
     def get_random_hidden_topic_id(self) -> int | None:
         with self.connect() as conn:
@@ -162,4 +156,4 @@ class DBClient:
 
 @lru_cache
 def get_db_client() -> DBClient:
-    return DBClient(db=sqlalchemy_get_pool())
+    return DBClient()

--- a/src/check_topics_by_upd_time/_legacy/main.py
+++ b/src/check_topics_by_upd_time/_legacy/main.py
@@ -3,7 +3,6 @@ which contain updates – and makes a pub/sub call for other script to parse con
 
 import ast
 import datetime
-import json
 import logging
 from concurrent.futures import ThreadPoolExecutor, wait
 from dataclasses import dataclass
@@ -11,13 +10,11 @@ from functools import lru_cache
 from typing import Any, Optional, no_type_check
 
 import requests
-import sqlalchemy
 from bs4 import BeautifulSoup, SoupStrainer, Tag
 from retry.api import retry_call
-from sqlalchemy.engine import Connection
-from sqlalchemy.engine.base import Engine
 
-from _dependencies.common.commons import get_forum_proxies, setup_logging, sqlalchemy_get_pool
+from _dependencies.common.commons import get_forum_proxies, setup_logging
+from _dependencies.common.db_client import DBClientBase, DBKeyValueStorageMixin
 from _dependencies.common.pubsub import Ctx, pubsub_parse_folders
 
 setup_logging(__package__)
@@ -27,43 +24,13 @@ USELESS_FOLDERS = {84, 113, 112, 270, 86, 87, 88, 165, 365, 89, 172, 91, 90, 316
 WORKERS_COUNT = 2
 
 
-class DBClient:
-    def __init__(self, db: Engine) -> None:
-        self._db = db
-
-    def connect(self) -> Connection:
-        return self._db.connect()
-
-    def get_key_value_item(self, key: str) -> Any:
-        with self.connect() as conn:
-            stmt = sqlalchemy.text("""
-                SELECT value FROM key_value_storage WHERE key=:key;
-                                   """)
-            raw_data = conn.execute(stmt, dict(key=key)).fetchone()
-            return raw_data[0] if raw_data else None
-
-    def set_key_value_item(self, key: str, value: Any) -> None:
-        with self.connect() as conn:
-            stmt = sqlalchemy.text("""
-                INSERT INTO key_value_storage 
-                (key, value) 
-                VALUES (:key, :value) 
-                ON CONFLICT (key) DO UPDATE SET value = :value ; 
-                                   """)
-            conn.execute(stmt, dict(key=key, value=json.dumps(value)))
-
-    def delete_key_value_item(self, key: str) -> None:
-        with self.connect() as conn:
-            stmt = sqlalchemy.text("""
-                DELETE FROM key_value_storage 
-                WHERE key=:key; 
-                                   """)
-            conn.execute(stmt, dict(key=key))
+class DBClient(DBClientBase, DBKeyValueStorageMixin):
+    """Legacy DBClient — now inherits from DBClientBase and DBKeyValueStorageMixin."""
 
 
 @lru_cache
 def get_db_client() -> DBClient:
-    return DBClient(db=sqlalchemy_get_pool())
+    return DBClient()
 
 
 @dataclass

--- a/src/identify_updates_of_topics/_legacy/_utils/database.py
+++ b/src/identify_updates_of_topics/_legacy/_utils/database.py
@@ -1,14 +1,10 @@
-import json
 import logging
-from contextlib import _GeneratorContextManager
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Any
 
 import sqlalchemy
-from sqlalchemy.engine.base import Engine
 
-from _dependencies.common.commons import sqlalchemy_get_pool
+from _dependencies.common.db_client import DBClientBase, DBKeyValueStorageMixin
 
 from .topics_commons import (
     ChangeLogLine,
@@ -18,12 +14,8 @@ from .topics_commons import (
 )
 
 
-class DBClient:
-    def __init__(self, db: Engine) -> None:
-        self._db = db
-
-    def connect(self) -> _GeneratorContextManager:
-        return self._db.begin()
+class DBClient(DBClientBase, DBKeyValueStorageMixin):
+    """Legacy DBClient — now inherits from DBClientBase and DBKeyValueStorageMixin."""
 
     def get_the_list_of_ignored_folders(self) -> list[int]:
         """get the list of folders which does not contain searches – thus should be ignored"""
@@ -411,33 +403,7 @@ class DBClient:
 
             return conn.execute(stmt).fetchall()
 
-    def get_key_value_item(self, key: str) -> Any:
-        with self.connect() as conn:
-            stmt = sqlalchemy.text("""
-                SELECT value FROM key_value_storage WHERE key=:key;
-                                   """)
-            raw_data = conn.execute(stmt, key=key).fetchone()
-            return raw_data[0] if raw_data else None
-
-    def set_key_value_item(self, key: str, value: Any) -> None:
-        with self.connect() as conn:
-            stmt = sqlalchemy.text("""
-                INSERT INTO key_value_storage 
-                (key, value) 
-                VALUES (:key, :value) 
-                ON CONFLICT (key) DO UPDATE SET value = :value ; 
-                                   """)
-            conn.execute(stmt, key=key, value=json.dumps(value))
-
-    def delete_key_value_item(self, key: str) -> None:
-        with self.connect() as conn:
-            stmt = sqlalchemy.text("""
-                DELETE FROM key_value_storage 
-                WHERE key=:key; 
-                                   """)
-            conn.execute(stmt, key=key)
-
 
 @lru_cache
 def get_db_client() -> DBClient:
-    return DBClient(db=sqlalchemy_get_pool())
+    return DBClient()


### PR DESCRIPTION
check_topics_by_upd_time, identify_updates_of_topics, and check_first_posts_for_changes had standalone DBClient classes that duplicated DBClientBase and DBKeyValueStorageMixin logic.

- All three now inherit from DBClientBase (and DBKeyValueStorageMixin where applicable)
- Removed duplicated __init__/connect/key_value methods
- Cleaned up unused imports (sqlalchemy_get_pool, Engine, Connection, json)