### PR TITLE
fix: reduce db pool size and fix pool_recycle (was 1s → 1h)

### DIFF
--- a/src/_dependencies/common/commons.py
+++ b/src/_dependencies/common/commons.py
@@ -55,8 +55,8 @@ class AppConfig(BaseSettings):
     forum_legacy_data_source: bool = False
 
     # Database connection pool settings
-    db_pool_size: int = 2
-    db_max_overflow: int = 4
+    db_pool_size: int = 1
+    db_max_overflow: int = 2
     db_pool_timeout: int = 10  # seconds
 
     @property
@@ -101,7 +101,7 @@ def sqlalchemy_get_pool_inner() -> sqlalchemy.engine.Engine:
         'pool_size': config.db_pool_size,
         'max_overflow': config.db_max_overflow,
         'pool_timeout': config.db_pool_timeout,  # seconds
-        'pool_recycle': 1,  # seconds
+        'pool_recycle': 3600,  # seconds (1 hour)
         'pool_pre_ping': True,
     }
 

--- a/src/_dependencies/common/lock_manager.py
+++ b/src/_dependencies/common/lock_manager.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Iterator
 
 from sqlalchemy import text
-from sqlalchemy.engine import Connection
+from sqlalchemy.engine import Connection, Engine
 
 logger = logging.getLogger(__name__)
 
@@ -14,28 +14,35 @@ class FunctionLockError(Exception):
 
 
 @contextmanager
-def lock_manager(conn: Connection, func_name: str, timeout_in_seconds: int) -> Iterator[None]:
-    """Context manager to avoid situation when many instances running one function"""
+def lock_manager(engine: Engine, func_name: str, timeout_in_seconds: int) -> Iterator[None]:
+    """Context manager to avoid situation when many instances running one function.
 
-    logger.info(f'Trying to lock function {func_name}')
-    if _check_if_another_function_is_running(conn, func_name, timeout_in_seconds):
-        logger.warning('Lock failed: another function is in progress')
-        raise FunctionLockError()
+    Uses its own short-lived transactions for lock acquire/release,
+    so connections are never left idle-in-transaction.
+    """
+    with engine.begin() as conn:
+        logger.info(f'Trying to lock function {func_name}')
+        if _check_if_another_function_is_running(conn, func_name, timeout_in_seconds):
+            logger.warning('Lock failed: another function is in progress')
+            raise FunctionLockError()
 
-    record_id = _write_function_start(conn, func_name)
+        record_id = _write_function_start(conn, func_name)
 
-    if _check_if_another_function_is_running(conn, func_name, timeout_in_seconds, record_id):
-        logger.warning('Lock failed: another function started in same time, cancelling current.')
-        _write_function_finish(conn, func_name, record_id)
-        raise FunctionLockError()
+        if _check_if_another_function_is_running(conn, func_name, timeout_in_seconds, record_id):
+            logger.warning('Lock failed: another function started in same time, cancelling current.')
+            _write_function_finish(conn, func_name, record_id)
+            raise FunctionLockError()
 
-    logger.info(f'Lock for function {func_name} is acuqired; {record_id=}')
+        logger.info(f'Lock for function {func_name} is acquired; {record_id=}')
+    # Transaction committed — lock record is visible, connection is freed
 
-    yield None
-
-    logger.info(f'Releasing function {func_name}')
-    _write_function_finish(conn, func_name, record_id)
-    logger.info(f'Lock for function {func_name} is released')
+    try:
+        yield None
+    finally:
+        with engine.begin() as conn:
+            logger.info(f'Releasing function {func_name}')
+            _write_function_finish(conn, func_name, record_id)
+            logger.info(f'Lock for function {func_name} is released')
 
 
 def _check_if_another_function_is_running(

--- a/src/compose_notifications/main.py
+++ b/src/compose_notifications/main.py
@@ -139,10 +139,10 @@ def main(event: dict, context: Ctx) -> None:
 
     function_id = generate_random_function_id()
 
-    pool = sqlalchemy_get_pool()
-    with pool.begin() as conn:
-        try:
-            with lock_manager(conn, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+    engine = sqlalchemy_get_pool()
+    try:
+        with lock_manager(engine, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+            with engine.begin() as conn:
                 # compose New Records List: the delta from Change log
                 new_record = LogRecordComposer(conn).get_line()
 
@@ -159,11 +159,10 @@ def main(event: dict, context: Ctx) -> None:
                     )
 
                 call_self_if_need_compose_more(conn, function_id)
-            # engine.begin() auto-commits on success, auto-rollbacks on exception
-        except FunctionLockError:
-            logging.info('function execution stopped due to parallel run with another function')
-            logging.info('script cancelled')
-            return None
+    except FunctionLockError:
+        logging.info('function execution stopped due to parallel run with another function')
+        logging.info('script cancelled')
+        return None
 
     analytics_finish = datetime.datetime.now()
     if new_record:

--- a/src/send_notifications/main.py
+++ b/src/send_notifications/main.py
@@ -656,15 +656,13 @@ def main(event: dict, context: Ctx) -> str | None:
 
     function_id = generate_random_function_id()
 
-    pool = sqlalchemy_get_pool()
-    with pool.begin() as connection:
-        try:
-            with lock_manager(connection, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
-                changed_ids = iterate_over_notifications(function_id, time_analytics)
-            # engine.begin() auto-commits on success, auto-rollbacks on exception
-        except FunctionLockError:
-            logging.info('script cancelled')
-            return None
+    engine = sqlalchemy_get_pool()
+    try:
+        with lock_manager(engine, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+            changed_ids = iterate_over_notifications(function_id, time_analytics)
+    except FunctionLockError:
+        logging.info('script cancelled')
+        return None
 
     finish_time_analytics(time_analytics, changed_ids)
 

--- a/tests/dependencies/test_lock_manager.py
+++ b/tests/dependencies/test_lock_manager.py
@@ -1,7 +1,9 @@
 from time import sleep
+from typing import Generator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.engine import Engine
 
 from _dependencies.common.lock_manager import FunctionLockError, lock_manager
 
@@ -13,22 +15,27 @@ class TestFunctionsLock:
     def func_name(self) -> str:
         return uuid4().hex[:30]
 
-    def test_is_locked(self, connection, func_name: str):
-        with lock_manager(connection, func_name, TIMEOUT):
+    @pytest.fixture(autouse=True)
+    def _engine(self, connection_pool: Engine) -> Generator[None, None, None]:
+        self.engine = connection_pool
+        yield
+
+    def test_is_locked(self, func_name: str):
+        with lock_manager(self.engine, func_name, TIMEOUT):
             with pytest.raises(FunctionLockError):
-                with lock_manager(connection, func_name, TIMEOUT):
+                with lock_manager(self.engine, func_name, TIMEOUT):
                     print('should fail')
 
-    def test_is_released_after_done(self, connection, func_name: str):
-        with lock_manager(connection, func_name, TIMEOUT):
+    def test_is_released_after_done(self, func_name: str):
+        with lock_manager(self.engine, func_name, TIMEOUT):
             print('ok')
 
         sleep(TIMEOUT)
-        with lock_manager(connection, func_name, TIMEOUT):
+        with lock_manager(self.engine, func_name, TIMEOUT):
             print('ok')
 
-    def test_is_released_by_timeout(self, connection, func_name: str):
-        with lock_manager(connection, func_name, TIMEOUT):
+    def test_is_released_by_timeout(self, func_name: str):
+        with lock_manager(self.engine, func_name, TIMEOUT):
             sleep(TIMEOUT)
-            with lock_manager(connection, func_name, TIMEOUT):
+            with lock_manager(self.engine, func_name, TIMEOUT):
                 print('should be done')


### PR DESCRIPTION
- pool_recycle: 1s → 3600s (was causing constant connection churn)
- db_pool_size: 2 → 1, db_max_overflow: 4 → 2 (max 3 conns/instance instead of 6, safer with 20-conn server limit)