### PR TITLE
fix: restore pool_size=2, keep max_overflow=2

### DIFF
--- a/src/_dependencies/common/commons.py
+++ b/src/_dependencies/common/commons.py
@@ -55,7 +55,7 @@ class AppConfig(BaseSettings):
     forum_legacy_data_source: bool = False
 
     # Database connection pool settings
-    db_pool_size: int = 1
+    db_pool_size: int = 2
     db_max_overflow: int = 2
     db_pool_timeout: int = 10  # seconds
 


### PR DESCRIPTION
pool_size=1 was too restrictive — send_notifications runs multiple concurrent DB queries (main thread + 2 ThreadPoolExecutor workers), causing contention with only 3 total connections.

Now: 4 conns/instance (2+2), 12-16 total at 3-4 instances — safe within the 20-connection server limit.