### PR TITLE
fix: Bad Request errors

### DIFF
--- a/src/communicate/_utils/common.py
+++ b/src/communicate/_utils/common.py
@@ -1,7 +1,7 @@
 import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Sequence, Union
+from typing import Any, ClassVar, Sequence, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 from telegram import (
@@ -28,10 +28,36 @@ class InlineButtonCallbackData(BaseModel):
     hash: int | None = Field(default=None)
     letter_to_show: str = Field(default='', alias='bs')
 
+    SEP: ClassVar[str] = '|'
+
     def as_str(self) -> str:
-        res = self.model_dump_json(by_alias=True, exclude_none=True, exclude_unset=True)
-        assert len(res) <= InlineKeyboardButton.MAX_CALLBACK_DATA
-        return res
+        return self.serialize()
+
+    def serialize(self) -> str:
+        parts = [
+            self.keyboard_name or '',
+            str(self.action) if self.action is not None else '',
+            str(self.hash) if self.hash is not None else '',
+            self.letter_to_show or '',
+        ]
+        result = self.SEP.join(parts)
+        assert (
+            len(result) <= InlineKeyboardButton.MAX_CALLBACK_DATA
+        ), f'callback_data too long ({len(result)} > {InlineKeyboardButton.MAX_CALLBACK_DATA}): {result!r}'
+        return result
+
+    @classmethod
+    def deserialize(cls, data: str) -> 'InlineButtonCallbackData':
+        parts = data.split(cls.SEP)
+        parts += [''] * (4 - len(parts))  # pad to 4 parts
+        kb_name = parts[0] or None
+        action_raw = parts[1]
+        action: str | int | None = action_raw if action_raw else None
+        if action is not None and action_raw.isdigit():
+            action = int(action_raw)
+        hash_val = int(parts[2]) if parts[2] else None
+        letter = parts[3] or ''
+        return cls(keyboard_name=kb_name, action=action, hash=hash_val, letter_to_show=letter)
 
 
 class UserInputState(str, Enum):

--- a/src/communicate/_utils/handler_context.py
+++ b/src/communicate/_utils/handler_context.py
@@ -114,8 +114,9 @@ class TGHandlerContext:
             'chat_id': self.user_id,
             'text': text,
             'message_id': message_id,
-            'reply_markup': reply_markup,
         }
+        if reply_markup is not None:
+            params['reply_markup'] = reply_markup
         self._tg_api.edit_message_text(params)
         self._save_dialog(text)
 
@@ -145,10 +146,11 @@ class TGHandlerContext:
         params = {
             'parse_mode': parse_mode,
             'disable_web_page_preview': disable_web_page_preview,
-            'reply_markup': reply_markup,
             'chat_id': self.user_id,
             'text': text,
         }
+        if reply_markup is not None:
+            params['reply_markup'] = reply_markup
         self._tg_api.send_message(params)
         self._save_dialog(text)
 
@@ -197,17 +199,19 @@ class TGHandlerContext:
                     'chat_id': self.user_id,
                     'text': text,
                     'message_id': last_user_message_id,
-                    'reply_markup': reply_markup,
                 }
+                if reply_markup is not None:
+                    params['reply_markup'] = reply_markup
                 self._tg_api.edit_message_text(params)
         else:
             params = {
                 'parse_mode': parse_mode,
                 'disable_web_page_preview': disable_web_page_preview,
-                'reply_markup': reply_markup,
                 'chat_id': self.user_id,
                 'text': text,
             }
+            if reply_markup is not None:
+                params['reply_markup'] = reply_markup
             self._tg_api.send_message(params)
 
     def _save_dialog(self, text: str) -> None:

--- a/src/communicate/_utils/handlers/callback_handlers.py
+++ b/src/communicate/_utils/handlers/callback_handlers.py
@@ -1,5 +1,4 @@
 import logging
-from ast import literal_eval
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Message
 
@@ -8,6 +7,7 @@ from _dependencies.common.commons import SearchFollowingMode
 from ..buttons import TopicTypeInlineKeyboardBuilder, reply_markup_main
 from ..common import (
     NOT_FOLLOWING_MARK,
+    InlineButtonCallbackData,
 )
 from ..decorators import tg_handle
 from ..handler_context import TGHandlerContext
@@ -200,10 +200,9 @@ def _get_pressed_button_row_index(markup: InlineKeyboardMarkup, pressed_button_h
     for index, ikb_row in enumerate(ikb):
         logging.info(f'{ikb_row=}')
         if ikb_row[0].callback_data:
-            button_data = literal_eval(str(ikb_row[0].callback_data))
-            # Check if the pushed button matches the one in the callback
+            button_data = InlineButtonCallbackData.deserialize(str(ikb_row[0].callback_data))
 
-            if button_data.get('hash') and int(button_data['hash']) == pressed_button_hash:
+            if button_data.hash and button_data.hash == pressed_button_hash:
                 return index
 
     return None

--- a/src/communicate/main.py
+++ b/src/communicate/main.py
@@ -105,7 +105,7 @@ def _get_basic_update_parameters(update: Update) -> UpdateBasicParams:
     if callback_query:
         callback_data_text = callback_query.data
         try:
-            got_callback = InlineButtonCallbackData.model_validate_json(callback_data_text)
+            got_callback = InlineButtonCallbackData.deserialize(callback_data_text)
         except Exception:
             logging.exception(f'callback dict was not recognized for {callback_data_text=}')
             notify_admin(f'callback dict was not recognized for {callback_data_text=}')


### PR DESCRIPTION
- compact callback_data format and filter None reply_markup
- InlineButtonCallbackData: switch from JSON to compact pipe-separated format (~2x shorter callback_data)
- Add serialize()/deserialize() methods; keep as_str() for backward compat
- Update parsing in main.py and callback_handlers.py (remove literal_eval)
- handler_context.py: strip reply_markup from API params when None to avoid 'object expected as reply markup' from Telegram