### PR TITLE
fix: distinguish 'message is not modified' from MESSAGE_TOO_LONG

### DIFF
--- a/src/_dependencies/bot/telegram_api_wrapper.py
+++ b/src/_dependencies/bot/telegram_api_wrapper.py
@@ -171,6 +171,10 @@ class TGApiBase:
                 return 'completed'
 
             elif response.status_code == 400:  # Bad Request
+                description = response_json.get('description', '')
+                if 'message is not modified' in description:
+                    logging.info(f'message not modified for user {user_id} (no-op), {response_json=}')
+                    return 'completed'
                 logging.exception(f'Bad Request: message to {user_id} was not sent, {response_json=}')
                 return 'cancelled_bad_request'
 

--- a/src/communicate/_utils/handler_context.py
+++ b/src/communicate/_utils/handler_context.py
@@ -119,9 +119,10 @@ class TGHandlerContext:
             params['reply_markup'] = reply_markup
         result = self._tg_api.edit_message_text(params)
         if result == 'cancelled_bad_request' and reply_markup is not None:
-            # Telegram says MESSAGE_TOO_LONG — retry without reply_markup
+            # Bad Request on edit — possibly MESSAGE_TOO_LONG or payload too large.
+            # Fall back to editing without reply_markup.
             logging.error(
-                f'MESSAGE_TOO_LONG on editMessageText (edit method) for user {self.user_id}, '
+                f'cancelled_bad_request on editMessageText (edit method) for user {self.user_id}, '
                 f'retrying without reply_markup'
             )
             fallback_params = {
@@ -216,9 +217,10 @@ class TGHandlerContext:
                     params['reply_markup'] = reply_markup
                 result = self._tg_api.edit_message_text(params)
                 if result == 'cancelled_bad_request' and reply_markup is not None:
-                    # Telegram says MESSAGE_TOO_LONG — retry without reply_markup
+                    # Bad Request on edit — possibly MESSAGE_TOO_LONG or payload too large.
+                    # Fall back to editing without reply_markup.
                     logging.error(
-                        f'MESSAGE_TOO_LONG on editMessageText for user {self.user_id}, '
+                        f'cancelled_bad_request on editMessageText for user {self.user_id}, '
                         f'retrying without reply_markup'
                     )
                     fallback_params = {
@@ -238,9 +240,10 @@ class TGHandlerContext:
                 params['reply_markup'] = reply_markup
             result = self._tg_api.send_message(params)
             if result == 'cancelled_bad_request' and reply_markup is not None:
-                # Telegram says MESSAGE_TOO_LONG — retry without reply_markup
+                # Bad Request on send — possibly MESSAGE_TOO_LONG or payload too large.
+                # Fall back to sending without reply_markup.
                 logging.error(
-                    f'MESSAGE_TOO_LONG on sendMessage for user {self.user_id}, ' f'retrying without reply_markup'
+                    f'cancelled_bad_request on sendMessage for user {self.user_id}, ' f'retrying without reply_markup'
                 )
                 fallback_params = {
                     'parse_mode': parse_mode,


### PR DESCRIPTION
Problem: _process_response_of_api_call returned 'cancelled_bad_request' for any HTTP 400, and handler_context interpreted ALL cancelled_bad_request as MESSAGE_TOO_LONG, falling back to edit without reply_markup. This caused inline keyboards to vanish when a user double-tapped the same button (Telegram returns 'message is not modified').

Fix:
- Added explicit check for 'message is not modified' in the 400 handler of _process_response_of_api_call; such replies now return 'completed' (no-op) instead of triggering the fallback path.
- Updated handler_context error messages to say 'cancelled_bad_request' instead of claiming MESSAGE_TOO_LONG.