### PR TITLE
fix: use raw string for regex backreference in message_composer.py

### DIFF
--- a/src/compose_notifications/_utils/message_composer.py
+++ b/src/compose_notifications/_utils/message_composer.py
@@ -234,7 +234,7 @@ class MessageComposer:
                 message += '➕Добавлено:\n'
                 for addition_line in saved_message.additions:
                     # majority of coords in RU: lat in [30-80], long in [20-180]
-                    updated_line = re.sub(COORD_PATTERN, '<code>\g<0></code>', addition_line)
+                    updated_line = re.sub(COORD_PATTERN, r'<code>\g<0></code>', addition_line)
                     message += f'{updated_line}\n'
         else:
             message = saved_message.message


### PR DESCRIPTION
Fixes SyntaxWarning 'invalid escape sequence \g' on Python 3.12+. \g<0> is a valid regex backreference but Python warned about raw \g before the engine got it. Changed to r-string — no behavior change.