### PR TITLE
fix: remove status='new' from register_vk_only_user to match registeк_new_user behavior

### DIFF
--- a/src/vk_bot/_utils/account_linking.py
+++ b/src/vk_bot/_utils/account_linking.py
@@ -54,8 +54,8 @@ def register_vk_only_user(vk_user_id: int, vk_user_name: str | None = None) -> i
         now = datetime.datetime.now()
         conn.execute(
             sqlalchemy.text("""
-                INSERT INTO users (user_id, internal_user_id, username_telegram, reg_date, status)
-                VALUES (:user_id, :internal_user_id, :username, :reg_date, :status)
+                INSERT INTO users (user_id, internal_user_id, username_telegram, reg_date)
+                VALUES (:user_id, :internal_user_id, :username, :reg_date)
                 ON CONFLICT (user_id) DO NOTHING
             """),
             {
@@ -63,7 +63,6 @@ def register_vk_only_user(vk_user_id: int, vk_user_name: str | None = None) -> i
                 'internal_user_id': internal_user_id,
                 'username': vk_user_name,
                 'reg_date': now,
-                'status': 'new',
             },
         )
 


### PR DESCRIPTION
VK-only users were created with status='new', but compose_users_list_for_change_log filters on status IS NULL OR status='unblocked'. This excluded all VK-only users from receiving notifications.

The fix aligns register_vk_only_user with register_new_user (used by Telegram/MAX) which leaves status as NULL by not setting it in the INSERT at all.

Fixes: all VK-only users not receiving search notifications.