### PR TITLE
fix: close aiohttp session in MaxClient to prevent Unclosed client session warnings

### DIFF
--- a/src/_dependencies/bot/messenger_clients.py
+++ b/src/_dependencies/bot/messenger_clients.py
@@ -8,7 +8,8 @@ into the abstract ``MessengerClient`` interface defined in
 
 import asyncio
 import random
-from typing import cast
+from collections.abc import Coroutine
+from typing import Any, cast
 
 from maxapi import Bot as MaxBot
 
@@ -122,6 +123,12 @@ class MaxClient(MessengerClient):
     The maxapi library is fully async, so synchronous ``send_message``
     and ``send_coordinates`` calls are bridged via ``asyncio.run()``.
 
+    Can be used as a context manager to ensure the underlying aiohttp
+    session is properly closed::
+
+        with MaxClient() as client:
+            client.send_message(...)
+
     NOTE: This is a minimal integration for sending notifications.
     Full interactive bot features (Dispatcher, webhooks, FSM) will
     be added separately in a dedicated MAX bot module.
@@ -139,6 +146,39 @@ class MaxClient(MessengerClient):
             self._bot: MaxBot = bot_instance
         else:
             self._bot = MaxBot()
+
+    def __enter__(self) -> 'MaxClient':
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Close the underlying aiohttp session if still open."""
+
+        async def _close() -> None:
+            session = self._bot.session
+            if session is not None and not session.closed:
+                await self._bot.close_session()
+
+        try:
+            asyncio.run(_close())
+        except RuntimeError:
+            pass  # event loop already closed — nothing we can do
+
+    def _run_and_close(self, coro: Coroutine[Any, Any, Any]) -> None:
+        """Run an async operation in its own event loop and close the session.
+
+        Ensures ``aiohttp.ClientSession`` is always closed within the
+        same event loop it was created on, preventing ``Unclosed client
+        session`` warnings on garbage collection.
+        """
+
+        async def _wrapped() -> None:
+            await self._bot.ensure_session()
+            try:
+                await coro
+            finally:
+                await self._bot.close_session()
+
+        asyncio.run(_wrapped())
 
     def send_message(self, user_identity: UserIdentity, text: str, **kwargs: object) -> SendResult:
         """Send a text message to a MAX user.
@@ -159,14 +199,13 @@ class MaxClient(MessengerClient):
             if parse_mode_str:
                 parse_mode = ParseMode(parse_mode_str)
 
-            async def _send() -> None:
-                await self._bot.send_message(
+            self._run_and_close(
+                self._bot.send_message(
                     user_id=user_id,
                     text=text,
                     parse_mode=parse_mode,
                 )
-
-            asyncio.run(_send())
+            )
             return SendResult(success=True, status='completed')
         except ValueError:
             return SendResult(success=False, status='cancelled_bad_request')
@@ -185,13 +224,12 @@ class MaxClient(MessengerClient):
             maps_url = f'https://yandex.ru/maps/?pt={lng},{lat}&z=15&l=map'
             text = f'📍 Координаты: {lat}, {lng}\n{maps_url}'
 
-            async def _send() -> None:
-                await self._bot.send_message(
+            self._run_and_close(
+                self._bot.send_message(
                     user_id=user_id,
                     text=text,
                 )
-
-            asyncio.run(_send())
+            )
             return SendResult(success=True, status='completed')
         except ValueError:
             return SendResult(success=False, status='cancelled_bad_request')

--- a/src/_dependencies/bot/messenger_clients.py
+++ b/src/_dependencies/bot/messenger_clients.py
@@ -12,6 +12,7 @@ from collections.abc import Coroutine
 from typing import Any, cast
 
 from maxapi import Bot as MaxBot
+from maxapi.enums import ParseMode
 
 from _dependencies.bot.telegram_api_wrapper import TGApiBase
 from _dependencies.bot.vk_api_client import VKApi, VkApiError
@@ -192,8 +193,6 @@ class MaxClient(MessengerClient):
         try:
             user_id = int(user_identity.messenger_user_id)
             parse_mode_str = cast('str | None', kwargs.get('parse_mode'))
-
-            from maxapi.enums import ParseMode
 
             parse_mode: ParseMode | None = None
             if parse_mode_str:

--- a/src/send_notifications/main.py
+++ b/src/send_notifications/main.py
@@ -26,26 +26,26 @@ def main(event: dict, context: Ctx) -> str | None:
     db_client = DBClient()
     vk_api = get_default_vk_api_client()
     tg_api = tg_api_main_account()
-    max_client = MaxClient()
 
-    sender = NotificationSender(
-        db_client=db_client,
-        vk_notificator=VKNotificator(vk_api),
-        tg_notificator=TelegramNotificator(tg_api),
-        max_notificator=MaxNotificator(max_client),
-    )
+    with MaxClient() as max_client:
+        sender = NotificationSender(
+            db_client=db_client,
+            vk_notificator=VKNotificator(vk_api),
+            tg_notificator=TelegramNotificator(tg_api),
+            max_notificator=MaxNotificator(max_client),
+        )
 
-    time_analytics = TimeAnalytics(script_start_time=datetime.datetime.now())
-    function_id = generate_random_function_id()
-    engine = sqlalchemy_get_pool()
+        time_analytics = TimeAnalytics(script_start_time=datetime.datetime.now())
+        function_id = generate_random_function_id()
+        engine = sqlalchemy_get_pool()
 
-    try:
-        with lock_manager(engine, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
-            changed_ids = sender.send_all(function_id, time_analytics)
-    except FunctionLockError:
-        logging.info('script cancelled')
-        return None
+        try:
+            with lock_manager(engine, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+                changed_ids = sender.send_all(function_id, time_analytics)
+        except FunctionLockError:
+            logging.info('script cancelled')
+            return None
 
-    sender.finish_analytics(time_analytics, changed_ids)
-    logging.info('script finished')
-    return 'ok'
+        sender.finish_analytics(time_analytics, changed_ids)
+        logging.info('script finished')
+        return 'ok'


### PR DESCRIPTION
- Add context manager protocol (__enter__/__exit__) to MaxClient
- Extract _run_and_close helper that ensures session is created and closed within the same event loop
- Wrap MaxClient usage in send_notifications/main.py with context manager
- Add runtime safety: __exit__ handles already-closed event loops

