### PR TITLE
refactor: typed TelegramMessage contract instead of raw dict

### DIFF
--- a/src/_dependencies/bot/messenger_clients.py
+++ b/src/_dependencies/bot/messenger_clients.py
@@ -17,6 +17,7 @@ from maxapi.enums import ParseMode
 from _dependencies.bot.telegram_api_wrapper import TGApiBase
 from _dependencies.bot.vk_api_client import VKApi, VkApiError
 from _dependencies.common.commons import Messenger, MessengerClient, SendResult, UserIdentity, get_app_config
+from _dependencies.common.telegram_message import TelegramMessage
 
 
 class TelegramClient(MessengerClient):
@@ -34,18 +35,14 @@ class TelegramClient(MessengerClient):
         self._api = tg_api or TGApiBase(prod_token, config.bot_api_host)
 
     def send_message(self, user_identity: UserIdentity, text: str, **kwargs: object) -> SendResult:
-        params: dict[str, object] = {
-            'chat_id': user_identity.messenger_user_id,
-            'text': text,
-        }
-        # Pop known Telegram-specific kwargs
-        disable_preview = kwargs.pop('disable_web_page_preview', None)
-        if disable_preview is not None:
-            params['disable_web_page_preview'] = bool(disable_preview)
-
-        params.update(kwargs)
-
-        status = self._api.send_message(params)
+        message = TelegramMessage(
+            text=text,
+            parse_mode=cast('str | None', kwargs.get('parse_mode')),
+            disable_web_page_preview=cast('bool | None', kwargs.get('disable_web_page_preview')),
+            reply_markup=kwargs.get('reply_markup'),
+        )
+        user_id = int(user_identity.messenger_user_id)
+        status = self._api.send_message(user_id, message)
         return self._to_send_result(status)
 
     def send_coordinates(self, user_identity: UserIdentity, lat: float, lng: float) -> SendResult:

--- a/src/_dependencies/bot/telegram_api_wrapper.py
+++ b/src/_dependencies/bot/telegram_api_wrapper.py
@@ -10,6 +10,7 @@ from yarl import URL
 
 from _dependencies.bot.users_management import ManageUserAction, update_user_status
 from _dependencies.common.commons import get_app_config
+from _dependencies.common.telegram_message import TelegramMessage
 
 
 class TelegramTransientError(Exception):
@@ -44,8 +45,8 @@ class TGApiBase:
         except Exception:
             logging.exception('Error in getting response from Telegram')
 
-    def send_message(self, params: dict, call_context: str = '') -> str:
-        user_id = params['chat_id']
+    def send_message(self, user_id: int, message: TelegramMessage, call_context: str = '') -> str:
+        params = _build_telegram_params(user_id, message)
         try:
             response = retry_call(
                 self._make_api_call,
@@ -66,9 +67,11 @@ class TGApiBase:
         response = self._make_api_call('sendLocation', params)
         return self._process_response_of_api_call(user_id, response)
 
-    def edit_message_text(self, params: dict, call_context: str = '') -> str:
+    def edit_message_text(self, user_id: int, message: TelegramMessage, call_context: str = '') -> str:
+        params = _build_telegram_params(user_id, message)
+        if message.message_id is not None:
+            params['message_id'] = message.message_id
         response = self._make_api_call('editMessageText', params, call_context)
-        user_id = params['chat_id']
         return self._process_response_of_api_call(user_id, response)
 
     def delete_message(self, chat_id: int, message_id: int) -> requests.Response | None:
@@ -204,6 +207,11 @@ class TGApiBase:
         except Exception:
             logging.exception(f'Response is corrupted. {response_json=}')
             return 'failed'
+
+
+def _build_telegram_params(user_id: int, message: TelegramMessage) -> dict:
+    """Build a Telegram API params dict from a user_id and TelegramMessage."""
+    return {'chat_id': user_id, **message.to_telegram_params()}
 
 
 def make_invite_text_for_user(user_id: int | str) -> str:

--- a/src/_dependencies/common/telegram_message.py
+++ b/src/_dependencies/common/telegram_message.py
@@ -1,0 +1,66 @@
+"""TelegramMessage — typed contract for Telegram outgoing messages.
+
+Replaces raw ``dict`` usage across the codebase: all ``send_message``
+and ``edit_message_text`` calls now accept a typed model instead of
+assembling and disassembling a loose dictionary.
+
+The model deliberately excludes ``chat_id`` — the recipient is always
+passed as a separate parameter at the call site (``user_id`` / ``chat_id``),
+which makes the contract explicit and removes the need to extract it
+from inside the dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class TelegramMessage(BaseModel):
+    """Outgoing Telegram message (text variant, ``sendMessage``).
+
+    Designed for both ``sendMessage`` and ``editMessageText`` calls:
+
+    - **``send_message``** — ``message_id`` is ignored
+    - **``edit_message_text``** — ``message_id`` **must** be set
+
+    ``reply_markup`` accepts a ``TelegramObject`` instance (e.g.
+    ``InlineKeyboardMarkup``, ``ReplyKeyboardMarkup``) directly.
+    Serialisation to ``dict`` is handled by ``TGApiBase._make_api_call``
+    just before the JSON call to the Telegram API.
+    """
+
+    text: str
+    """Message text (plain text or HTML/Markdown)."""
+
+    parse_mode: str | None = 'HTML'
+    """Telegram parse mode (``'HTML'``, ``'MarkdownV2'``, or ``None``)."""
+
+    disable_web_page_preview: bool | None = True
+    """Disable link previews in the message."""
+
+    reply_markup: Any = None
+    """Reply markup (inline keyboard, reply keyboard, etc.).
+
+    Accepts ``TelegramObject`` (from python-telegram-bot) or a raw
+    ``dict``.  ``TelegramObject`` instances are converted to ``dict``
+    via ``.to_dict()`` inside ``TGApiBase._make_api_call``.
+    """
+
+    message_id: int | None = None
+    """Message ID to edit (only used by ``edit_message_text``).
+
+    Must be set when calling ``edit_message_text``; ignored by
+    ``send_message``.
+    """
+
+    def to_telegram_params(self) -> dict[str, Any]:
+        """Convert message content to a Telegram API ``params`` slice (without ``chat_id``).
+
+        ``None`` fields are excluded so the Telegram API uses its
+        own defaults.  ``reply_markup`` values that are
+        ``TelegramObject`` instances will be serialised just before
+        the HTTP call in ``_make_api_call``.
+        """
+        return self.model_dump(exclude_none=True)

--- a/src/communicate/_utils/handler_context.py
+++ b/src/communicate/_utils/handler_context.py
@@ -8,6 +8,8 @@ import logging
 
 from telegram import InlineKeyboardMarkup, Message, ReplyKeyboardMarkup, ReplyKeyboardRemove
 
+from _dependencies.common.telegram_message import TelegramMessage
+
 from .common import UpdateBasicParams, UpdateExtraParams, UserInputState
 from .database import DBClient
 from .message_sending import TGApiCommunicate
@@ -110,14 +112,12 @@ class TGHandlerContext:
             if isinstance(message, Message):
                 message_id = message.id
 
-        params = {
-            'chat_id': self.user_id,
-            'text': text,
-            'message_id': message_id,
-        }
-        if reply_markup is not None:
-            params['reply_markup'] = reply_markup
-        result = self._tg_api.edit_message_text(params)
+        tg_message = TelegramMessage(
+            text=text,
+            reply_markup=reply_markup,
+            message_id=message_id,
+        )
+        result = self._tg_api.edit_message_text(self.user_id, tg_message)
         if result == 'cancelled_bad_request' and reply_markup is not None:
             # Bad Request on edit — possibly MESSAGE_TOO_LONG or payload too large.
             # Fall back to editing without reply_markup.
@@ -125,12 +125,12 @@ class TGHandlerContext:
                 f'cancelled_bad_request on editMessageText (edit method) for user {self.user_id}, '
                 f'retrying without reply_markup'
             )
-            fallback_params = {
-                'chat_id': self.user_id,
-                'text': text,
-                'message_id': message_id,
-            }
-            self._tg_api.edit_message_text(fallback_params)
+            fallback_message = TelegramMessage(
+                text=text,
+                message_id=message_id,
+            )
+            self._tg_api.edit_message_text(self.user_id, fallback_message)
+
         self._save_dialog(text)
 
     def answer_callback(self, text: str = '') -> None:
@@ -156,15 +156,13 @@ class TGHandlerContext:
         and does NOT clear dialog state. Use for multi-message responses
         after the primary ``.reply()``.
         """
-        params = {
-            'parse_mode': parse_mode,
-            'disable_web_page_preview': disable_web_page_preview,
-            'chat_id': self.user_id,
-            'text': text,
-        }
-        if reply_markup is not None:
-            params['reply_markup'] = reply_markup
-        self._tg_api.send_message(params)
+        message = TelegramMessage(
+            text=text,
+            parse_mode=parse_mode,
+            disable_web_page_preview=disable_web_page_preview,
+            reply_markup=reply_markup,
+        )
+        self._tg_api.send_message(self.user_id, message)
         self._save_dialog(text)
 
     def delete_inline_dialogue(self) -> None:
@@ -208,14 +206,12 @@ class TGHandlerContext:
                     logging.warning(f'no reply_markup or text in {callback_query=}')
 
                 last_user_message_id = message.id
-                params = {
-                    'chat_id': self.user_id,
-                    'text': text,
-                    'message_id': last_user_message_id,
-                }
-                if reply_markup is not None:
-                    params['reply_markup'] = reply_markup
-                result = self._tg_api.edit_message_text(params)
+                edit_message = TelegramMessage(
+                    text=text,
+                    reply_markup=reply_markup,
+                    message_id=last_user_message_id,
+                )
+                result = self._tg_api.edit_message_text(self.user_id, edit_message)
                 if result == 'cancelled_bad_request' and reply_markup is not None:
                     # Bad Request on edit — possibly MESSAGE_TOO_LONG or payload too large.
                     # Fall back to editing without reply_markup.
@@ -223,35 +219,31 @@ class TGHandlerContext:
                         f'cancelled_bad_request on editMessageText for user {self.user_id}, '
                         f'retrying without reply_markup'
                     )
-                    fallback_params = {
-                        'chat_id': self.user_id,
-                        'text': text,
-                        'message_id': last_user_message_id,
-                    }
-                    self._tg_api.edit_message_text(fallback_params)
+                    fallback_message = TelegramMessage(
+                        text=text,
+                        message_id=last_user_message_id,
+                    )
+                    self._tg_api.edit_message_text(self.user_id, fallback_message)
         else:
-            params = {
-                'parse_mode': parse_mode,
-                'disable_web_page_preview': disable_web_page_preview,
-                'chat_id': self.user_id,
-                'text': text,
-            }
-            if reply_markup is not None:
-                params['reply_markup'] = reply_markup
-            result = self._tg_api.send_message(params)
+            send_message = TelegramMessage(
+                text=text,
+                parse_mode=parse_mode,
+                disable_web_page_preview=disable_web_page_preview,
+                reply_markup=reply_markup,
+            )
+            result = self._tg_api.send_message(self.user_id, send_message)
             if result == 'cancelled_bad_request' and reply_markup is not None:
                 # Bad Request on send — possibly MESSAGE_TOO_LONG or payload too large.
                 # Fall back to sending without reply_markup.
                 logging.error(
                     f'cancelled_bad_request on sendMessage for user {self.user_id}, ' f'retrying without reply_markup'
                 )
-                fallback_params = {
-                    'parse_mode': parse_mode,
-                    'disable_web_page_preview': disable_web_page_preview,
-                    'chat_id': self.user_id,
-                    'text': text,
-                }
-                self._tg_api.send_message(fallback_params)
+                fallback_message = TelegramMessage(
+                    text=text,
+                    parse_mode=parse_mode,
+                    disable_web_page_preview=disable_web_page_preview,
+                )
+                self._tg_api.send_message(self.user_id, fallback_message)
 
     def _save_dialog(self, text: str) -> None:
         """Save bot reply to dialog history."""

--- a/src/communicate/_utils/handlers/button_handlers.py
+++ b/src/communicate/_utils/handlers/button_handlers.py
@@ -15,6 +15,7 @@ from _dependencies.bot.telegram_api_wrapper import make_invite_text_for_user
 from _dependencies.bot.users_management import ManageUserAction, save_onboarding_step
 from _dependencies.common.commons import add_tel_link, get_app_config
 from _dependencies.common.pubsub import notify_admin
+from _dependencies.common.telegram_message import TelegramMessage
 from _dependencies.models import AgePeriod
 
 from ..buttons import (
@@ -877,11 +878,11 @@ def send_invite_vk_message_to_user(ctx: TGHandlerContext) -> None:
     inline_markup = InlineKeyboardMarkup([[btn_open_vk_chat]])
 
     ctx.tg_api.send_message(
-        {
-            'chat_id': ctx.user_id,
-            'text': bot_message,
-            'parse_mode': 'markdown',
-            'disable_web_page_preview': True,
-            'reply_markup': inline_markup,
-        }
+        ctx.user_id,
+        TelegramMessage(
+            text=bot_message,
+            parse_mode='markdown',
+            disable_web_page_preview=True,
+            reply_markup=inline_markup,
+        ),
     )

--- a/src/communicate/_utils/handlers/other_handlers.py
+++ b/src/communicate/_utils/handlers/other_handlers.py
@@ -3,6 +3,7 @@ import logging
 from telegram import Update
 
 from _dependencies.common.pubsub import notify_admin
+from _dependencies.common.telegram_message import TelegramMessage
 
 from ..buttons import CoordinateSettingsMenu, b_back_to_start, b_menu_set_region
 from ..common import (
@@ -67,8 +68,7 @@ def process_unneeded_messages(update: Update, update_params: UpdateBasicParams) 
             'Пожалуйста, воспользуйтесь текстовыми кнопками бота, находящимися на '
             'месте обычной клавиатуры телеграм.'
         )
-        data = {'text': bot_message, 'chat_id': user_id}
-        tg_api().send_message(data)
+        tg_api().send_message(user_id, TelegramMessage(text=bot_message))
         return True
 
     # CASE 4 – when some Channel writes to bot
@@ -90,8 +90,7 @@ def process_unneeded_messages(update: Update, update_params: UpdateBasicParams) 
             'Спасибо, буду знать. Вот только бот не работает с контактами и отвечает '
             'только на определенные текстовые команды.'
         )
-        data = {'text': bot_message, 'chat_id': user_id}
-        tg_api().send_message(data)
+        tg_api().send_message(user_id, TelegramMessage(text=bot_message))
         return True
 
     # CASE 6 – when user mentions bot as @LizaAlert_Searcher_Bot in another telegram chat. Bot should do nothing

--- a/src/communicate/_utils/handlers/region_select_handlers.py
+++ b/src/communicate/_utils/handlers/region_select_handlers.py
@@ -1,6 +1,7 @@
 from telegram import ReplyKeyboardRemove
 
 from _dependencies.bot.users_management import save_onboarding_step
+from _dependencies.common.telegram_message import TelegramMessage
 
 from ..buttons import (
     IsMoscow,
@@ -108,11 +109,11 @@ def _handle_region_selection_inline_menu(ctx: TGHandlerContext) -> None:
     selected_regions = geography.forum_folders_to_regions_list(user_curr_regs_list)
 
     ctx.tg_api.send_message(
-        {
-            'chat_id': ctx.user_id,
-            'text': bot_message,
-            'reply_markup': ReplyKeyboardRemove(),
-        }
+        ctx.user_id,
+        TelegramMessage(
+            text=bot_message,
+            reply_markup=ReplyKeyboardRemove(),
+        ),
     )
 
     reply_keyboard = geography.get_inline_keyboard_by_first_letter('+', selected_regions)

--- a/src/communicate/_utils/handlers/view_searches_handlers.py
+++ b/src/communicate/_utils/handlers/view_searches_handlers.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from _dependencies.common.misc import age_writer, time_counter_since_search_start
+from _dependencies.common.telegram_message import TelegramMessage
 
 from ..buttons import Commands, MainMenu, OtherOptionsMenu, reply_markup_main
 from ..common import (
@@ -251,17 +252,15 @@ def _show_button_to_turn_on_following_searches(ctx: TGHandlerContext) -> None:
     ]
     reply_markup = InlineKeyboardMarkup(search_follow_mode_ikb)
     ctx.tg_api.send_message(
-        {
-            'parse_mode': 'HTML',
-            'disable_web_page_preview': True,
-            'reply_markup': reply_markup.to_dict(),
-            'chat_id': ctx.user_id,
-            'text': (
+        ctx.user_id,
+        TelegramMessage(
+            text=(
                 'Вы можете включить возможность выбора поисков для отслеживания, '
                 'чтобы получать уведомления не со всех актуальных поисков, '
                 'а только с выбранных Вами.'
             ),
-        },
+            reply_markup=reply_markup.to_dict(),
+        ),
         f'{ctx.user_id=}, context_step=a01',
     )
 
@@ -338,13 +337,11 @@ def _handle_view_searches_experimental_view(ctx: TGHandlerContext, search_list_t
         logging.info(f'{bot_message=}; {region_data.rows=}; context_step=b00')
 
         ctx.tg_api.send_message(
-            {
-                'parse_mode': 'HTML',
-                'disable_web_page_preview': True,
-                'reply_markup': reply_markup_inline,
-                'chat_id': user_id,
-                'text': bot_message,
-            },
+            user_id,
+            TelegramMessage(
+                text=bot_message,
+                reply_markup=reply_markup_inline,
+            ),
             f'{user_id=}, context_step=b03',
         )
 

--- a/src/communicate/_utils/message_sending.py
+++ b/src/communicate/_utils/message_sending.py
@@ -4,8 +4,9 @@ from functools import lru_cache
 import requests
 from requests.models import Response
 
-from _dependencies.bot.telegram_api_wrapper import TGApiBase
+from _dependencies.bot.telegram_api_wrapper import TGApiBase, _build_telegram_params
 from _dependencies.common.commons import get_app_config
+from _dependencies.common.telegram_message import TelegramMessage
 
 from .database import db
 
@@ -23,9 +24,9 @@ class TGApiCommunicate(TGApiBase):
         logging.info(f'_make_api_call. {method=}, {params=}, {call_context=}')
         return super()._make_api_call(method, params, call_context)
 
-    def send_message(self, params: dict, call_context: str = '') -> str:
+    def send_message(self, user_id: int, message: TelegramMessage, call_context: str = '') -> str:
+        params = _build_telegram_params(user_id, message)
         response = self._make_api_call('sendMessage', params, call_context)
-        user_id = params['chat_id']
         result = self._process_response_of_api_call(user_id, response)
 
         logging.info(f'RESPONSE {response}')
@@ -34,9 +35,11 @@ class TGApiCommunicate(TGApiBase):
         _inline_processing(response, params)
         return result
 
-    def edit_message_text(self, params: dict, call_context: str = '') -> str:
+    def edit_message_text(self, user_id: int, message: TelegramMessage, call_context: str = '') -> str:
+        params = _build_telegram_params(user_id, message)
+        if message.message_id is not None:
+            params['message_id'] = message.message_id
         response = self._make_api_call('editMessageText', params, call_context)
-        user_id = params['chat_id']
         result = self._process_response_of_api_call(user_id, response)
 
         logging.info(f'RESPONSE {response}')

--- a/src/communicate/main.py
+++ b/src/communicate/main.py
@@ -16,6 +16,7 @@ from _dependencies.bot.users_management import (
 from _dependencies.common.commons import Messenger, get_app_config, setup_logging
 from _dependencies.common.misc import RequestWrapper, ResponseWrapper, request_response_converter
 from _dependencies.common.pubsub import notify_admin
+from _dependencies.common.telegram_message import TelegramMessage
 
 from ._utils.buttons import reply_markup_main
 from ._utils.common import (
@@ -154,14 +155,13 @@ def _process_block_unblock_user(user_id: int, user_new_status: str) -> None:
     keyboard_main = [['посмотреть актуальные поиски'], ['настроить бот'], ['другие возможности']]
     reply_markup = ReplyKeyboardMarkup(keyboard_main, resize_keyboard=True)
 
-    data = {
-        'text': bot_message,
-        'reply_markup': reply_markup,
-        'parse_mode': 'HTML',
-        'chat_id': user_id,
-        'disable_web_page_preview': True,
-    }
-    tg_api().send_message(data)
+    message = TelegramMessage(
+        text=bot_message,
+        parse_mode='HTML',
+        disable_web_page_preview=True,
+        reply_markup=reply_markup,
+    )
+    tg_api().send_message(user_id, message)
 
 
 def _run_onboarding(user_id: int, username: str, onboarding_step_id: int, got_message: str) -> int:

--- a/src/connect_to_forum/main.py
+++ b/src/connect_to_forum/main.py
@@ -13,6 +13,7 @@ from telegram import ReplyKeyboardMarkup
 from _dependencies.bot.messaging import tg_api_main_account
 from _dependencies.common.commons import get_app_config, get_forum_proxies, setup_logging
 from _dependencies.common.pubsub import Ctx, MessageForParseUserProfile, process_pubsub_message
+from _dependencies.common.telegram_message import TelegramMessage
 from _dependencies.models import DialogState
 
 from ._utils.database import DBClient
@@ -325,16 +326,13 @@ def main(event: Dict[str, bytes], context: Ctx) -> None:
             logging.exception('failed to update the last saved message from bot')
 
     reply_markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
-    data = {
-        'text': bot_message,
-        'reply_markup': reply_markup,
-        'parse_mode': 'HTML',
-        'disable_web_page_preview': True,
-        'chat_id': tg_user_id,
-    }
+    tg_message = TelegramMessage(
+        text=bot_message,
+        reply_markup=reply_markup,
+    )
 
     tg_api = tg_api_main_account()
-    tg_api.send_message(data)
+    tg_api.send_message(tg_user_id, tg_message)
 
     # save bot's reply to incoming request
     if bot_message:

--- a/src/send_debug_to_admin/main.py
+++ b/src/send_debug_to_admin/main.py
@@ -6,6 +6,7 @@ from retry import retry
 from _dependencies.bot.messaging import tg_api_service_account
 from _dependencies.common.commons import get_app_config, setup_logging
 from _dependencies.common.pubsub import Ctx, process_pubsub_message
+from _dependencies.common.telegram_message import TelegramMessage
 
 setup_logging(__package__)
 
@@ -20,8 +21,8 @@ def send_message(admin_user_id: int, message: str) -> None:
     if len(message) > 3500:
         message = message[:1500]
 
-    params = {'chat_id': admin_user_id, 'text': message}
-    tg_api.send_message(params)
+    tg_message = TelegramMessage(text=message)
+    tg_api.send_message(admin_user_id, tg_message)
 
 
 def main(event: dict[str, bytes], context: Ctx) -> None:

--- a/src/send_notifications/_utils/clients/telegram_notificator.py
+++ b/src/send_notifications/_utils/clients/telegram_notificator.py
@@ -2,6 +2,7 @@
 
 from _dependencies.bot.telegram_api_wrapper import TGApiBase
 from _dependencies.common.message_params import MessageParams
+from _dependencies.common.telegram_message import TelegramMessage
 from send_notifications._utils.database import MessageToSend
 
 
@@ -13,15 +14,13 @@ class TelegramNotificator:
 
     def send_text(self, user_id: int, content: str, message_params: MessageParams) -> str | None:
         """Send a text message via Telegram API."""
-        payload: dict = {
-            'chat_id': user_id,
-            'text': content,
-            'parse_mode': message_params.parse_mode,
-            'disable_web_page_preview': message_params.disable_web_page_preview,
-        }
-        if message_params.reply_markup is not None:
-            payload['reply_markup'] = message_params.reply_markup
-        return self._tg_api.send_message(payload)
+        message = TelegramMessage(
+            text=content,
+            parse_mode=message_params.parse_mode,
+            disable_web_page_preview=message_params.disable_web_page_preview,
+            reply_markup=message_params.reply_markup,
+        )
+        return self._tg_api.send_message(user_id, message)
 
     def send_location(self, user_id: int, latitude: float, longitude: float) -> str | None:
         """Send coordinates via Telegram API."""


### PR DESCRIPTION
Вводит TelegramMessage (Pydantic) как типизированный контракт для отправки сообщений в Telegram API. chat_id вынесен в отдельный параметр методов send_message / edit_message_text.

Изменения:
- Новая модель TelegramMessage в _dependencies/common/telegram_message.py
- TGApiBase.send_message(user_id, message, ...) вместо send_message(params)
- TGApiBase.edit_message_text(user_id, message, ...) вместо edit_message_text(params)
- Все вызывающие переписаны на новый контракт (13 файлов)
- TelegramObject для reply_markup принимается напрямую, сериализация внутри TGApiBase._make_api_call (как и раньше)
- MessageParams (kind/coords) оставлен для хранения в БД

Closes [#34](https://github.com/volodkindv/la_searcher_bot/issues/34)