### PR TITLE
fix(send_debug_to_admin): escape HTML entities in debug messages

### DIFF
--- a/src/send_debug_to_admin/main.py
+++ b/src/send_debug_to_admin/main.py
@@ -1,6 +1,8 @@
 """Script send the Debug messages to Admin via special Debug Bot in telegram https://t.me/la_test_1_bot
 To receive notifications one should be marked as Admin in PSQL"""
 
+import html
+
 from retry import retry
 
 from _dependencies.bot.messaging import tg_api_service_account
@@ -21,7 +23,11 @@ def send_message(admin_user_id: int, message: str) -> None:
     if len(message) > 3500:
         message = message[:1500]
 
-    tg_message = TelegramMessage(text=message)
+    # Debug messages may contain repr of PTB objects (e.g. ChatType.PRIVATE)
+    # wrapped in angle brackets that Telegram would try to parse as HTML.
+    # Escape HTML entities to avoid parse errors.
+    safe_message = html.escape(message)
+    tg_message = TelegramMessage(text=safe_message)
     tg_api.send_message(admin_user_id, tg_message)
 
 


### PR DESCRIPTION
TelegramMessage defaults to parse_mode='HTML', so angle brackets in PTB object repr (e.g. Chat(type=<ChatType.PRIVATE>)) get interpreted as HTML tags and cause Bad Request parse errors.

Wrap the message text with html.escape() before sending to avoid false-positive HTML tag detection.

Closes #issue-with-4-admin-errors