### PR TITLE
fix(notifications): escape raw forum HTML and truncate messages without breaking tags

### DIFF
--- a/src/compose_notifications/_utils/log_record_composer.py
+++ b/src/compose_notifications/_utils/log_record_composer.py
@@ -1,4 +1,5 @@
 import datetime
+import html
 import logging
 
 from _dependencies.common.commons import ChangeType
@@ -229,7 +230,9 @@ def make_clickable_name(line: LineInChangeLog) -> None:
     else:  # if it's event or something else
         link_text = line.title
 
-    line.clickable_name = f'<a href="{line.link}">{link_text}</a>'
+    # link_text is forum-derived (display_name / title) — escape so raw < > & in it
+    # can't break Telegram's parse_mode=HTML (the href itself is built from numbers).
+    line.clickable_name = f'<a href="{line.link}">{html.escape(link_text)}</a>'
 
 
 def define_family_name(title_string: str, predefined_fam_name: str | None) -> str:

--- a/src/compose_notifications/_utils/message_composer.py
+++ b/src/compose_notifications/_utils/message_composer.py
@@ -1,4 +1,5 @@
 import ast
+import html
 import logging
 import re
 from functools import lru_cache
@@ -16,6 +17,24 @@ from .commons import (
 )
 
 FIB_LIST = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987]
+
+# Tags that legacy first-post diffs embed intentionally around deleted/added forum text.
+# Everything else in such messages is raw forum content and must be escaped.
+_LEGACY_FIRST_POST_TAG_RE = re.compile(r'(</?s>|</?code>)')
+
+
+def _escape_legacy_first_post_message(fragment: str) -> str:
+    """Escape raw forum text in a legacy first-post diff, keeping only <s>/<code> tags.
+
+    Old change_log records store the diff as a plain string with ``<s>``/``<code>``
+    already embedded — escape the surrounding text (which may contain raw ``< > &``)
+    while preserving those structural tags.
+    """
+    return ''.join(
+        part if part in ('<s>', '</s>', '<code>', '</code>') else html.escape(part)
+        for part in _LEGACY_FIRST_POST_TAG_RE.split(fragment)
+        if part
+    )
 
 
 class MessageComposer:
@@ -143,7 +162,7 @@ class MessageComposer:
         else:
             status_info = line.status
 
-        message = f'{status_info} – изменение статуса по {line.clickable_name}'
+        message = f'{html.escape(status_info)} – изменение статуса по {line.clickable_name}'
 
         if user.user_in_multi_folders and line.region:
             message += f' ({line.region})'
@@ -155,7 +174,7 @@ class MessageComposer:
         line = self.new_record
 
         activity = 'мероприятия' if line.topic_type_id == TopicType.event else 'поиска'
-        msg = f'{line.title} – обновление заголовка {activity} по {line.clickable_name}'
+        msg = f'{html.escape(line.title)} – обновление заголовка {activity} по {line.clickable_name}'
 
         return msg
 
@@ -170,9 +189,13 @@ class MessageComposer:
         for comment in line.comments:
             if comment.text:
                 comment_text = f'{comment.text[:500]}...' if len(comment.text) > 500 else comment.text
+                # Forum text may contain raw < > & (phpBB entities are decoded by BeautifulSoup),
+                # which breaks Telegram's parse_mode=HTML — escape before embedding.
+                comment_text = html.escape(comment_text)
+                author_nickname = html.escape(comment.author_nickname)
 
                 msg += (
-                    f' &#8226; <a href="{url_prefix}{comment.author_link}">{comment.author_nickname}</a>: '
+                    f' &#8226; <a href="{url_prefix}{comment.author_link}">{author_nickname}</a>: '
                     f'<i>«<a href="{comment.url}">{comment_text}</a>»</i>\n'
                 )
 
@@ -193,8 +216,8 @@ class MessageComposer:
         title_str, region_str, comment_str, author = '', '', '', ''
         for comment in line.comments_inforg:
             if comment.text:
-                author = f'<a href="{url_prefix}{comment.author_link}">{comment.author_nickname}</a>'
-                comment_str += f'<i>«<a href="{comment.url}">{comment.text}</a>»</i>\n'
+                author = f'<a href="{url_prefix}{comment.author_link}">{html.escape(comment.author_nickname)}</a>'
+                comment_str += f'<i>«<a href="{comment.url}">{html.escape(comment.text)}</a>»</i>\n'
 
         comment_str = f':\n{comment_str}'
 
@@ -223,7 +246,8 @@ class MessageComposer:
             if saved_message.deletions:
                 message += '➖Удалено:\n<s>'
                 for deletion_line in saved_message.deletions:
-                    message += f'{deletion_line}\n'
+                    # raw forum text may contain < > & — escape before wrapping in <s>
+                    message += f'{html.escape(deletion_line)}\n'
                 message += '</s>'
 
             if saved_message.additions:
@@ -231,11 +255,14 @@ class MessageComposer:
                     message += '\n'
                 message += '➕Добавлено:\n'
                 for addition_line in saved_message.additions:
+                    # escape first: coords still match COORD_PATTERN (digits/dots/spaces only)
                     # majority of coords in RU: lat in [30-80], long in [20-180]
-                    updated_line = re.sub(COORD_PATTERN, r'<code>\g<0></code>', addition_line)
+                    updated_line = re.sub(COORD_PATTERN, r'<code>\g<0></code>', html.escape(addition_line))
                     message += f'{updated_line}\n'
         else:
-            message = saved_message.message
+            # legacy plain-string diffs already contain intentional <s>/<code> tags —
+            # escape the raw forum text around them
+            message = _escape_legacy_first_post_message(saved_message.message)
 
         if not message:
             return ''
@@ -339,7 +366,9 @@ def _get_managers_from_text(managers: str) -> str:
     try:
         managers_str = 'Ответственные:'
         for manager in ast.literal_eval(managers):
-            manager_line = add_tel_link(manager)
+            # manager is forum-derived text — escape before add_tel_link so raw < > & can't
+            # break HTML, while phone numbers (digits/spaces only) are still linked
+            manager_line = add_tel_link(html.escape(manager))
             managers_str += f'\n &#8226; {manager_line}'
 
     except Exception:

--- a/src/send_notifications/_utils/services/notification_sender.py
+++ b/src/send_notifications/_utils/services/notification_sender.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
+from html.parser import HTMLParser
 from typing import Any
 
 from _dependencies.common.commons import Messenger
@@ -226,6 +227,91 @@ class NotificationSender:
         time_analytics.parsed_times.append(duration_complete_vs_parsed_time_minutes)
 
 
+MAX_TELEGRAM_MESSAGE_CHARS = 4000  # Telegram hard limit is 4096 chars; leave headroom
+MAX_TELEGRAM_MESSAGE_HARD_LIMIT = 4096
+
+_VOID_ELEMENTS = {
+    'area',
+    'base',
+    'br',
+    'col',
+    'embed',
+    'hr',
+    'img',
+    'input',
+    'link',
+    'meta',
+    'param',
+    'source',
+    'track',
+    'wbr',
+}
+
+
+class _OpenTagsCollector(HTMLParser):
+    """Track tags that are opened but not closed in an HTML fragment."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self.stack: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # void elements (e.g. <br>) never need a closing tag
+        if tag not in _VOID_ELEMENTS:
+            self.stack.append(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in self.stack:
+            while self.stack and self.stack[-1] != tag:
+                self.stack.pop()
+            if self.stack:
+                self.stack.pop()
+
+
+def _close_open_tags(fragment: str) -> str:
+    """Append closing tags for any tags left open in `fragment`."""
+    collector = _OpenTagsCollector()
+    collector.feed(fragment)
+    collector.close()
+    return fragment + ''.join(f'</{tag}>' for tag in reversed(collector.stack))
+
+
+def _cut_after_last_tag(fragment: str) -> str:
+    """Cut `fragment` right after its last complete tag, never splitting a tag in half."""
+    last_gt = fragment.rfind('>')
+    if last_gt > 0:
+        return fragment[: last_gt + 1]
+    return fragment
+
+
+def _truncate_html_message(content: str, limit: int = MAX_TELEGRAM_MESSAGE_CHARS) -> str:
+    """Truncate `content` to `limit` chars without breaking HTML tags.
+
+    A naive mid-text cut slices through ``<a>``/``<i>`` tags and makes Telegram's
+    parse_mode=HTML fail with "Can't find end tag corresponding to start tag ...".
+    This cuts at the last comment block boundary (``\\n &#8226;``) when present,
+    otherwise backs up to the last completed tag and closes any tags left open,
+    so the result stays valid HTML and never exceeds Telegram's 4096-char limit.
+    """
+    if len(content) <= limit:
+        return content
+
+    head = content[:limit]
+
+    # Prefer a clean cut between comment blocks: tags are always balanced there.
+    boundary = head.rfind('\n &#8226;')
+    if boundary > 0:
+        return head[:boundary].rstrip()
+
+    head = _cut_after_last_tag(head)
+    result = _close_open_tags(head)
+    # Appended closing tags must not push the message past Telegram's hard limit.
+    while len(result) > MAX_TELEGRAM_MESSAGE_HARD_LIMIT:
+        head = _cut_after_last_tag(head[:-1])
+        result = _close_open_tags(head)
+    return result
+
+
 def _prepare_message(
     message_to_send: MessageToSend,
 ) -> tuple[str, MessageParams]:
@@ -234,8 +320,8 @@ def _prepare_message(
     message_params_str = message_to_send.message_params
 
     # limitation to avoid telegram "message too long"
-    if message_content and len(message_content) > 3000:
-        message_content = f'{message_content[:1500]}...{message_content[-1000:]}'
+    if message_content:
+        message_content = _truncate_html_message(message_content)
 
     if message_params_str:
         try:

--- a/tests/test_compose_notifications/test_message_composer.py
+++ b/tests/test_compose_notifications/test_message_composer.py
@@ -4,7 +4,7 @@ import pytest
 from polyfactory.factories import DataclassFactory
 
 from _dependencies.common.commons import ChangeLogSavedValue, ChangeType, TopicType
-from compose_notifications._utils.commons import LineInChangeLog, User
+from compose_notifications._utils.commons import Comment, LineInChangeLog, User
 from compose_notifications._utils.log_record_composer import make_clickable_name, make_emoji
 from compose_notifications._utils.message_composer import MessageComposer
 from tests.test_compose_notifications.factories import UserFactory
@@ -52,6 +52,19 @@ class TestCommonMessageComposerClickableName:
         assert not record.clickable_name
         make_clickable_name(record)
         assert record.title in record.clickable_name
+
+    def test_clickable_name_escapes_html(self):
+        """Raw < > & in forum title/display_name must not break Telegram HTML."""
+        record = LineInChageFactory.build(
+            topic_type_id=TopicType.info,
+            title='Поиск <b>Иванов</b> & Ко ><',
+        )
+        make_clickable_name(record)
+        assert '&lt;b&gt;' in record.clickable_name
+        assert '&amp;' in record.clickable_name
+        assert '&gt;&lt;' in record.clickable_name
+        assert '<b>' not in record.clickable_name
+        assert record.clickable_name.count('<a ') == record.clickable_name.count('</a>')
 
 
 @pytest.fixture
@@ -119,6 +132,17 @@ class TestMessageComposer:
         assert 'изменение статуса по' in message
         assert record.clickable_name in message
 
+    def test_topic_status_change_escapes_html(self, user: User):
+        """Raw < > & in status text must not break Telegram HTML."""
+        record = LineInChageFactory.build(
+            change_type=ChangeType.topic_status_change,
+            topic_type_id=TopicType.search_info_support,
+            status='Найден <b>&</b>',
+        )
+        message = MessageComposer(record).compose_message_for_user(user)
+        assert '&lt;b&gt;&amp;&lt;/b&gt;' in message
+        assert '<b>' not in message
+
     def test_topic_title_change(self, user: User):
         record = LineInChageFactory.build(
             change_type=ChangeType.topic_title_change,
@@ -127,6 +151,18 @@ class TestMessageComposer:
         message = MessageComposer(record).compose_message_for_user(user)
         assert 'обновление заголовка мероприятия по' in message
         assert record.clickable_name in message
+
+    def test_topic_title_change_escapes_html(self, user: User):
+        """Raw < > & in forum title must not break Telegram HTML."""
+        record = LineInChageFactory.build(
+            change_type=ChangeType.topic_title_change,
+            topic_type_id=TopicType.event,
+            title='Заголовок с <i>тегом</i> & символом',
+        )
+        message = MessageComposer(record).compose_message_for_user(user)
+        assert '&lt;i&gt;тегом&lt;/i&gt;' in message
+        assert '&amp;' in message
+        assert '<i>тегом' not in message
 
     def test_topic_comment_new(self, user: User):
         record = LineInChageFactory.build(
@@ -137,6 +173,35 @@ class TestMessageComposer:
         assert 'Новые комментарии по поиску' in message
         assert record.clickable_name in message
 
+    def test_topic_comment_new_escapes_html(self, user: User):
+        """Raw < > & in forum comment text must not break Telegram HTML."""
+        record = LineInChageFactory.build(
+            change_type=ChangeType.topic_comment_new,
+            topic_type_id=TopicType.search_regular,
+            comments=[
+                Comment(
+                    url='https://lizaalert.org/forum/viewtopic.php?&t=371693&start=31',
+                    text='Сойка выехала домой <i>срочно & ждём "всех"',
+                    author_nickname='SOIKA LA',
+                    author_link='101319',
+                ),
+                Comment(
+                    url='https://lizaalert.org/forum/viewtopic.php?&t=371693&start=32',
+                    text='обычный текст',
+                    author_nickname='Ник ><',
+                    author_link='101320',
+                ),
+            ],
+        )
+        message = MessageComposer(record).compose_message_for_user(user)
+        assert '&lt;i&gt;' in message
+        assert '&amp;' in message
+        assert '&quot;' in message
+        assert '&gt;&lt;' in message
+        assert '<i>срочно' not in message
+        assert message.count('<i>') == message.count('</i>')
+        assert message.count('<a ') == message.count('</a>')
+
     def test_topic_inforg_comment_new(self, user: User):
         record = LineInChageFactory.build(
             change_type=ChangeType.topic_inforg_comment_new,
@@ -144,6 +209,26 @@ class TestMessageComposer:
         message = MessageComposer(record).compose_message_for_user(user)
         assert 'Сообщение от ' in message
         assert record.clickable_name in message
+
+    def test_topic_inforg_comment_new_escapes_html(self, user: User):
+        """Raw < > & in inforg comment text must not break Telegram HTML."""
+        record = LineInChageFactory.build(
+            change_type=ChangeType.topic_inforg_comment_new,
+            comments_inforg=[
+                Comment(
+                    url='https://lizaalert.org/forum/viewtopic.php?&t=371693&start=1',
+                    text='Штаб свернут <b>резерв</b> & всё',
+                    author_nickname='Инфорг поста',
+                    author_link='101319',
+                )
+            ],
+        )
+        message = MessageComposer(record).compose_message_for_user(user)
+        assert '&lt;b&gt;' in message
+        assert '&amp;' in message
+        assert '<b>резерв</b>' not in message
+        assert message.count('<i>') == message.count('</i>')
+        assert message.count('<a ') == message.count('</a>')
 
     def test_topic_first_post_change_1(self, user: User):
         new_value = r"{'del': ['Иван (Иванов)'], 'add': [], 'message': 'Удалено:\n<s>Иван (Иванов)\n</s>'}"
@@ -218,6 +303,57 @@ class TestMessageComposer:
             '➕Добавлено:\nНовые координаты <code>57.1234 61.12345</code>\n\n\nКоординаты сместились на ~126 км &#8601;&#xFE0E;'
             in message
         )
+
+    def test_topic_first_post_change_escapes_html(self, user: User):
+        """Raw < > & in first-post diff lines must not break Telegram HTML."""
+        new_value = (
+            r"{'del': ['Иван <b>(Иванов)</b> & сын'], 'add': ['Новые координаты 57.1234 61.12345 <i>срочно</i>']}"
+        )
+        record = LineInChageFactory.build(
+            change_type=ChangeType.topic_first_post_change,
+            topic_type_id=TopicType.search_regular,
+            new_value=new_value,
+            search_latitude='56.1234',
+            search_longitude='60.1234',
+        )
+        message = MessageComposer(record).compose_message_for_user(user)
+        assert '&lt;b&gt;(Иванов)&lt;/b&gt; &amp; сын' in message
+        assert '&lt;i&gt;срочно&lt;/i&gt;' in message
+        assert '<b>' not in message
+        assert '<i>срочно' not in message
+        # coordinates are still wrapped in <code> for the location pin
+        assert 'Новые координаты <code>57.1234 61.12345</code>' in message
+        assert message.count('<s>') == message.count('</s>')
+        assert message.count('<code>') == message.count('</code>')
+        assert message.count('<i>') == message.count('</i>')
+
+    def test_topic_first_post_change_legacy_message_escapes_html(self, user: User):
+        """Legacy plain-string diffs: text is escaped, intentional <s> tags survive."""
+        new_value = '➖Удалено: <s><b>Ожидается выезд</b> срочно!</s> ➕Добавлено: Штаб & штаб начнёт <i>работу</i>'
+        record = LineInChageFactory.build(
+            change_type=ChangeType.topic_first_post_change,
+            topic_type_id=TopicType.search_regular,
+            new_value=new_value,
+        )
+        message = MessageComposer(record).compose_message_for_user(user)
+        assert '<s>&lt;b&gt;Ожидается выезд&lt;/b&gt; срочно!</s>' in message
+        assert '&amp;' in message
+        assert '&lt;i&gt;работу&lt;/i&gt;' in message
+        assert '<b>Ожидается' not in message
+        assert message.count('<s>') == message.count('</s>')
+
+    def test_topic_new_search_escapes_managers_html(self, user: User):
+        """Raw < > & in manager names from forum must not break Telegram HTML."""
+        record = LineInChageFactory.build(
+            change_type=ChangeType.topic_new,
+            start_time=datetime.now(),
+            topic_type_id=TopicType.search_regular,
+            managers='["Инфорг <i>Иван</i> +79001234567"]',
+        )
+        message = MessageComposer(record).compose_message_for_user(user)
+        assert 'Инфорг &lt;i&gt;Иван&lt;/i&gt;  <a href="tel:+79001234567">' in message
+        assert '<i>Иван</i>' not in message
+        assert message.count('<a ') == message.count('</a>')
 
 
 def test_parse_change_log_saved_value_dict():

--- a/tests/test_send_notifications.py
+++ b/tests/test_send_notifications.py
@@ -24,7 +24,12 @@ from send_notifications._utils.helpers import (
 from send_notifications._utils.models import (
     TimeAnalytics,
 )
-from send_notifications._utils.services.notification_sender import NotificationSender, _prepare_message
+from send_notifications._utils.services.notification_sender import (
+    MAX_TELEGRAM_MESSAGE_CHARS,
+    NotificationSender,
+    _close_open_tags,
+    _prepare_message,
+)
 from tests.common import find_model
 from tests.factories.db_factories import NotifByUserFactory, UserFactory, get_session
 from tests.factories.db_models import NotifByUser
@@ -495,12 +500,62 @@ class TestHelpers:
         assert not time_is_out(start)
 
     def test_prepare_message_truncates_long_text(self):
-        long_text = 'A' * 4000
+        """Plain text > Telegram limit → cut at the limit, no tags to break."""
+        long_text = 'A' * 4500
         msg = _make_msg(message_content=long_text)
         content, _ = _prepare_message(msg)
-        assert len(content) == 1500 + 3 + 1000  # 1500 + '...' + 1000
-        assert content.startswith('A' * 1500)
-        assert content.endswith('A' * 1000)
+        assert len(content) == MAX_TELEGRAM_MESSAGE_CHARS
+        assert content == 'A' * MAX_TELEGRAM_MESSAGE_CHARS
+
+    def test_prepare_message_truncates_at_comment_boundary(self):
+        """Long comment message → cut at a comment block boundary, tags stay balanced."""
+        header = 'Новые комментарии по поиску <a href="https://lizaalert.org/forum/viewtopic.php?t=1">Тест</a>:\n'
+        comment = (
+            ' &#8226; <a href="https://lizaalert.org/forum/memberlist.php?mode=viewprofile&u=1">Ник</a>: '
+            '<i>«<a href="https://lizaalert.org/forum/viewtopic.php?&t=1&start=1">комментарий</a>»</i>\n'
+        )
+        long_text = header + comment * 25
+        assert len(long_text) > MAX_TELEGRAM_MESSAGE_CHARS
+
+        msg = _make_msg(message_content=long_text)
+        content, _ = _prepare_message(msg)
+        assert len(content) <= MAX_TELEGRAM_MESSAGE_CHARS
+        assert content.count('<i>') == content.count('</i>')
+        assert content.count('<a ') == content.count('</a>')
+        assert content.rstrip().endswith('»</i>')
+
+    def test_prepare_message_closes_open_tags(self):
+        """Generic HTML cut mid-tag → open tags are closed, result stays valid."""
+        long_text = '<i>«<a href="https://lizaalert.org/forum/viewtopic.php?&t=1&start=1">' + 'A' * 4500
+        msg = _make_msg(message_content=long_text)
+        content, _ = _prepare_message(msg)
+        assert content.count('<i>') == content.count('</i>')
+        assert content.count('<a ') == content.count('</a>')
+        assert content.endswith('</a></i>')
+
+    def test_prepare_message_never_exceeds_telegram_hard_limit(self):
+        """Even with extreme tag nesting, appended closing tags can't push past 4096."""
+        long_text = 'A' * 3900 + '<i>' * 34 + 'X' * 5000
+        msg = _make_msg(message_content=long_text)
+        content, _ = _prepare_message(msg)
+        assert len(content) <= 4096
+        assert content.count('<i>') == content.count('</i>')
+
+    def test_prepare_message_keeps_br_void_element_unclosed(self):
+        """<br> must not get a spurious closing tag when tags are balanced around it."""
+        long_text = '<i>текст<br>ещё текст</i>' + 'A' * 4500
+        msg = _make_msg(message_content=long_text)
+        content, _ = _prepare_message(msg)
+        assert '</br>' not in content
+        assert content.count('<i>') == content.count('</i>')
+        assert '<br>' in content
+
+    def test_close_open_tags_ignores_void_elements(self):
+        """Void elements (<br>) are not pushed to the open-tags stack."""
+        fragment = '<i>текст<br><a href="https://x">ссылка'
+        result = _close_open_tags(fragment)
+        assert result == '<i>текст<br><a href="https://x">ссылка</a></i>'
+        assert '</br>' not in result
 
     def test_prepare_message_parses_disable_web_page_preview(self):
         msg = _make_msg(message_params='{"parse_mode": "HTML", "disable_web_page_preview": "True"}')
@@ -733,15 +788,14 @@ class TestSendOne:
         assert recipient == '54321'
 
     def test_truncates_long_text(self, sender: NotificationSender, fake_tg: FakeTelegramNotificator):
-        """message_content > 3000 chars → truncated to 1500 + ... + 1000."""
-        long_text = 'A' * 4000
+        """message_content > Telegram limit → truncated without breaking HTML tags."""
+        long_text = 'A' * 4500
         msg = _make_msg(messenger='telegram', message_content=long_text)
         sender._send_one(msg)
         assert len(fake_tg.sent_messages) == 1
         _, _, content, _ = fake_tg.sent_messages[0]
-        assert len(content) == 1500 + 3 + 1000  # 1500 + '...' + 1000
-        assert content.startswith('A' * 1500)
-        assert content.endswith('A' * 1000)
+        assert len(content) == MAX_TELEGRAM_MESSAGE_CHARS
+        assert content == 'A' * MAX_TELEGRAM_MESSAGE_CHARS
 
     def test_parses_disable_web_page_preview(self, sender: NotificationSender, fake_tg: FakeTelegramNotificator):
         """message_params with disable_web_page_preview='True' → converted to bool True."""


### PR DESCRIPTION
Telegram's parse_mode=HTML rejects messages with unclosed or misnested tags ("Can't find end tag corresponding to start tag 'i'"). Forum content (comment text, author nicknames, titles, statuses, manager names, first-post diffs) was embedded raw, and the old truncation ([:1500]...[-1000:]) cut mid-tag. Fix: html.escape all forum-derived text before embedding, keep intentional `<s> / <code>` tags in legacy first-post diffs, and replace naive truncation with tag-aware cutting + closing open tags (hard cap 4096).