### PR TITLE
fix(lock_manager): replace race-prone table lock with PG advisory lock

### DIFF
--- a/src/_dependencies/common/lock_manager.py
+++ b/src/_dependencies/common/lock_manager.py
@@ -1,99 +1,51 @@
+"""PostgreSQL advisory-lock based mutual exclusion for cloud functions."""
+
 import logging
 from contextlib import contextmanager
-from datetime import datetime, timedelta
 from typing import Iterator
 
 from sqlalchemy import text
-from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.engine import Engine
 
 logger = logging.getLogger(__name__)
 
 
 class FunctionLockError(Exception):
-    pass
+    """Raised when another instance of the same function is already running."""
 
 
 @contextmanager
-def lock_manager(engine: Engine, func_name: str, timeout_in_seconds: int) -> Iterator[None]:
-    """Context manager to avoid situation when many instances running one function.
+def lock_manager(engine: Engine, func_name: str) -> Iterator[None]:
+    """Prevent parallel execution of the same cloud function.
 
-    Uses its own short-lived transactions for lock acquire/release,
-    so connections are never left idle-in-transaction.
+    Uses a session-scoped PostgreSQL advisory lock keyed by a hash of
+    ``func_name``. The lock is acquired with ``pg_try_advisory_lock``
+    (non-blocking): if it is already held by another connection,
+    ``FunctionLockError`` is raised immediately.
+
+    Advisory locks are released automatically by the server when the
+    connection closes — including on process crash — so there is no
+    stale-lock problem and no need for a timeout, unlike the previous
+    table-based ``functions_registry`` approach.
     """
-    with engine.begin() as conn:
-        logger.info(f'Trying to lock function {func_name}')
-        if _check_if_another_function_is_running(conn, func_name, timeout_in_seconds):
-            logger.warning('Lock failed: another function is in progress')
-            raise FunctionLockError()
+    conn = engine.connect()
+    acquired = conn.execute(
+        text('SELECT pg_try_advisory_lock(hashtextextended(:func_name, 0))'),
+        {'func_name': func_name},
+    ).scalar()
 
-        record_id = _write_function_start(conn, func_name)
+    if not acquired:
+        conn.close()
+        logger.warning('Lock failed: another function is in progress')
+        raise FunctionLockError()
 
-        if _check_if_another_function_is_running(conn, func_name, timeout_in_seconds, record_id):
-            logger.warning('Lock failed: another function started in same time, cancelling current.')
-            _write_function_finish(conn, func_name, record_id)
-            raise FunctionLockError()
-
-        logger.info(f'Lock for function {func_name} is acquired; {record_id=}')
-    # Transaction committed — lock record is visible, connection is freed
-
+    logger.info(f'Lock for function {func_name} is acquired')
     try:
         yield None
     finally:
-        with engine.begin() as conn:
-            logger.info(f'Releasing function {func_name}')
-            _write_function_finish(conn, func_name, record_id)
-            logger.info(f'Lock for function {func_name} is released')
-
-
-def _check_if_another_function_is_running(
-    conn: Connection, func_name: str, timeout_in_seconds: int, current_run_id: int = 0
-) -> bool:
-    now = datetime.now()
-    txt = text("""
-                    SELECT 
-                        id 
-                    FROM
-                        functions_registry
-                    WHERE
-                        time_start > :time_start AND
-                        time_finish IS NULL AND
-                        id != :current_run_id AND
-                        cloud_function_name  = :func_name
-                    LIMIT 1
-                    ;""")
-
-    start_time = now - timedelta(seconds=timeout_in_seconds)
-    res = conn.execute(txt, dict(time_start=start_time, func_name=func_name, current_run_id=current_run_id))
-
-    rows = list(res)
-    return bool(rows)
-
-
-def _write_function_start(conn: Connection, func_name: str) -> int:
-    sql_text = text("""
-                        INSERT INTO 
-                            functions_registry
-                        (time_start, cloud_function_name)
-                        VALUES
-                        (:start_time, :func_name )
-                        RETURNING id;
-                        ;
-                            """)
-    res = conn.execute(sql_text, dict(func_name=func_name, start_time=datetime.now()))
-    row = res.first()
-    if row is None:
-        raise RuntimeError(f'Failed to write function start for {func_name}')
-    return row[0]
-
-
-def _write_function_finish(conn: Connection, func_name: str, record_id: int) -> None:
-    sql_text = text("""
-                        UPDATE
-                            functions_registry
-                        SET
-                            time_finish = :finish_time
-                        WHERE
-                            id=:record_id
-                        ;
-                    """)
-    conn.execute(sql_text, dict(record_id=record_id, finish_time=datetime.now()))
+        conn.execute(
+            text('SELECT pg_advisory_unlock(hashtextextended(:func_name, 0))'),
+            {'func_name': func_name},
+        )
+        conn.close()
+        logger.info(f'Lock for function {func_name} is released')

--- a/src/compose_notifications/main.py
+++ b/src/compose_notifications/main.py
@@ -14,7 +14,6 @@ from ._utils.log_record_composer import LogRecordComposer
 from ._utils.notifications_maker import NotificationMaker
 from ._utils.users_list_composer import UserListFilter, UsersListComposer
 
-INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS = 250
 FUNC_NAME = 'compose_notifications'
 
 
@@ -76,7 +75,7 @@ def main(event: dict, context: Ctx) -> None:
     new_record: LineInChangeLog | None = None
     analytics_iterations_finish: datetime.datetime | None = None
     try:
-        with lock_manager(db._db, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+        with lock_manager(db._db, FUNC_NAME):
             # compose New Records List: the delta from Change log
             new_record = LogRecordComposer(db).get_line()
 

--- a/src/send_notifications/_utils/helpers.py
+++ b/src/send_notifications/_utils/helpers.py
@@ -6,7 +6,6 @@ import re
 FUNC_NAME = 'send_notifications'
 
 SCRIPT_SOFT_TIMEOUT_SECONDS = 40  # after which iterations should stop to prevent the whole script timeout
-INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS = 50  # window within which we check for started parallel function
 SLEEP_TIME_FOR_NEW_NOTIFS_RECHECK_SECONDS = 5
 WORKERS_COUNT = 2
 

--- a/src/send_notifications/main.py
+++ b/src/send_notifications/main.py
@@ -14,7 +14,7 @@ from send_notifications._utils.clients.max_notificator import MaxNotificator
 from send_notifications._utils.clients.telegram_notificator import TelegramNotificator
 from send_notifications._utils.clients.vk_notificator import VKNotificator
 from send_notifications._utils.database import DBClient
-from send_notifications._utils.helpers import FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS
+from send_notifications._utils.helpers import FUNC_NAME
 from send_notifications._utils.models import TimeAnalytics
 from send_notifications._utils.services.notification_sender import NotificationSender
 
@@ -40,7 +40,7 @@ def main(event: dict, context: Ctx) -> str | None:
         engine = sqlalchemy_get_pool()
 
         try:
-            with lock_manager(engine, FUNC_NAME, INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS):
+            with lock_manager(engine, FUNC_NAME):
                 changed_ids = sender.send_all(function_id, time_analytics)
         except FunctionLockError:
             logging.info('script cancelled')

--- a/tests/dependencies/test_lock_manager.py
+++ b/tests/dependencies/test_lock_manager.py
@@ -1,4 +1,3 @@
-from time import sleep
 from typing import Generator
 from uuid import uuid4
 
@@ -6,8 +5,6 @@ import pytest
 from sqlalchemy.engine import Engine
 
 from _dependencies.common.lock_manager import FunctionLockError, lock_manager
-
-TIMEOUT = 1
 
 
 class TestFunctionsLock:
@@ -20,22 +17,33 @@ class TestFunctionsLock:
         self.engine = connection_pool
         yield
 
-    def test_is_locked(self, func_name: str):
-        with lock_manager(self.engine, func_name, TIMEOUT):
+    def test_is_locked_while_held(self, func_name: str):
+        """Second acquisition attempt must fail while the lock is held."""
+        with lock_manager(self.engine, func_name):
             with pytest.raises(FunctionLockError):
-                with lock_manager(self.engine, func_name, TIMEOUT):
+                with lock_manager(self.engine, func_name):
                     print('should fail')
 
     def test_is_released_after_done(self, func_name: str):
-        with lock_manager(self.engine, func_name, TIMEOUT):
+        """The lock must be free again immediately after the context exits."""
+        with lock_manager(self.engine, func_name):
             print('ok')
 
-        sleep(TIMEOUT)
-        with lock_manager(self.engine, func_name, TIMEOUT):
+        with lock_manager(self.engine, func_name):
             print('ok')
 
-    def test_is_released_by_timeout(self, func_name: str):
-        with lock_manager(self.engine, func_name, TIMEOUT):
-            sleep(TIMEOUT)
-            with lock_manager(self.engine, func_name, TIMEOUT):
-                print('should be done')
+    def test_is_released_on_exception(self, func_name: str):
+        """The lock must be released even if the body raises."""
+        with pytest.raises(RuntimeError):
+            with lock_manager(self.engine, func_name):
+                raise RuntimeError('boom')
+
+        # no timeout / sleep needed — advisory lock is freed on connection close
+        with lock_manager(self.engine, func_name):
+            print('ok after exception')
+
+    def test_different_functions_do_not_block(self):
+        """Two different func_names must not contend for the same lock."""
+        with lock_manager(self.engine, 'fn_a'):
+            with lock_manager(self.engine, 'fn_b'):
+                print('both held')


### PR DESCRIPTION
The previous lock_manager checked for a running function, inserted a time_start row, then re-checked — three non-atomic steps under READ COMMITTED, so two concurrent invocations could both acquire the lock (observed: record_id 1490623 and 1490624, 170ms apart, both processing change_log 687953).

Switch to a session-scoped PostgreSQL advisory lock keyed by hashtextextended(func_name, 0). pg_try_advisory_lock is atomic and the lock is released automatically when the connection closes (including on crash), removing the stale-lock timeout and the functions_registry table dependency.

Also drop the now-unused timeout_in_seconds parameter and INTERVAL_TO_CHECK_PARALLEL_FUNCTION_SECONDS constants.