### PR TITLE
feat(communicate): promote inline search list to production for all u…

### DIFF
--- a/src/communicate/_utils/buttons.py
+++ b/src/communicate/_utils/buttons.py
@@ -25,8 +25,6 @@ b_act_titles = 'названия'  # these are "Title update notification" butto
 # admin and experimental options
 b_admin_menu = 'admin'
 b_test_menu = 'test'
-b_test_search_follow_mode_on = 'test search follow mode on'  # noqa
-b_test_search_follow_mode_off = 'test search follow mode off'
 
 
 # Settings - Fed Dist - Regions

--- a/src/communicate/_utils/handlers/button_handlers.py
+++ b/src/communicate/_utils/handlers/button_handlers.py
@@ -37,8 +37,6 @@ from ..buttons import (
     b_coords_auto_def,
     b_menu_set_region,
     b_test_menu,
-    b_test_search_follow_mode_off,
-    b_test_search_follow_mode_on,
     c_start,
     reply_markup_main,
 )
@@ -134,8 +132,6 @@ def handle_command_other(ctx: TGHandlerContext) -> None:
         b_admin_menu,
         b_test_menu,
         'notest',
-        b_test_search_follow_mode_on,
-        b_test_search_follow_mode_off,
         'test msg 1',
         'test msg 2',
     ]
@@ -207,18 +203,6 @@ def handle_admin_experimental_settings(ctx: TGHandlerContext) -> None:
 Дуглас
 Герда (Арина) 89001234567 """
         bot_message = add_tel_link(bot_message)
-        ctx.reply(text=bot_message, reply_markup=reply_markup_main)
-        return
-
-    if got_message.lower() == b_test_search_follow_mode_on:  # issue425
-        ctx.db.set_search_follow_mode(user_id, True)
-        bot_message = 'Возможность отслеживания поисков включена. Возвращаемся в главное меню.'
-        ctx.reply(text=bot_message, reply_markup=reply_markup_main)
-        return
-
-    if got_message.lower() == b_test_search_follow_mode_off:  ##remains for some time for emrgency case
-        ctx.db.set_search_follow_mode(user_id, False)
-        bot_message = 'Возможность отслеживания поисков вЫключена. Возвращаемся в главное меню.'
         ctx.reply(text=bot_message, reply_markup=reply_markup_main)
         return
 

--- a/src/communicate/_utils/handlers/callback_handlers.py
+++ b/src/communicate/_utils/handlers/callback_handlers.py
@@ -105,29 +105,11 @@ def _handle_topic_type_pressed_about(ctx: TGHandlerContext, welcome_message: str
     ctx.edit(text=bot_message, reply_markup=InlineKeyboardMarkup(keyboard))
 
 
-@tg_handle(callback_data=['search_follow_mode_on', 'search_follow_mode_off', 'search_follow_clear'])
-def handle_search_follow_mode(ctx: TGHandlerContext) -> None:
-    """Switches search following mode on/off, or clears search following marks"""
-
-    user_callback = ctx.update_params.got_callback
-    callback_query = ctx.update_params.callback_query
+@tg_handle(callback_data='search_follow_clear')
+def handle_search_follow_clear(ctx: TGHandlerContext) -> None:
     user_id = ctx.user_id
-
-    logging.info(f'{callback_query=}, {user_id=}')
-    # when user pushed INLINE BUTTON for topic following
-    if user_callback and user_callback.action == 'search_follow_mode_on':
-        ctx.db.set_search_follow_mode(user_id, True)
-        bot_message = 'Режим выбора поисков для отслеживания включен. Переоткройте список активных поисков.'
-
-    elif user_callback and user_callback.action == 'search_follow_mode_off':
-        ctx.db.set_search_follow_mode(user_id, False)
-        bot_message = 'Режим выбора поисков для отслеживания отключен. Переоткройте список активных поисков.'
-
-    elif user_callback and user_callback.action == 'search_follow_clear':
-        ctx.db.delete_search_whiteness(user_id)
-        bot_message = 'Все пометки отслеживания поисков сброшены. Переоткройте список активных поисков.'
-
-    ctx.reply(text=bot_message)
+    ctx.db.delete_search_whiteness(user_id)
+    ctx.reply(text='Все пометки отслеживания поисков сброшены. Переоткройте список активных поисков.')
 
 
 @tg_handle(callback_data='search_follow_mode')

--- a/src/communicate/_utils/handlers/view_searches_handlers.py
+++ b/src/communicate/_utils/handlers/view_searches_handlers.py
@@ -153,118 +153,6 @@ def _compose_ikb_of_active_searches(
     return SearchesIKBData(msg, folder_url, rows)
 
 
-def _compose_text_message_of_all_searches(db_client: 'DBClient', forum_folder_num: int, region_name: str) -> str:
-    """Compose a Final message on the list of ALL searches in the given region"""
-
-    # download the list from SEARCHES sql table
-    searches = db_client.get_all_searches_in_one_region_limit_20(forum_folder_num)
-
-    _format_searches_for_display(searches)
-    lines = [
-        f'{search.new_status} <a href="{SEARCH_URL_PREFIX}{search.topic_id}">{search.display_name}</a>'
-        for search in searches
-    ]
-
-    folder_url = f'{FORUM_FOLDER_PREFIX}{forum_folder_num}'
-    # combine the list of last 20 searches
-
-    if lines:
-        lines.insert(0, f'Последние 20 поисков в разделе <a href="{folder_url}">{region_name}</a>:')
-        return '\n'.join(lines)
-    else:
-        return _get_message_last_searches_not_found(region_name, forum_folder_num)
-
-
-def _compose_text_message_on_active_searches(
-    db_client: 'DBClient', forum_folder_num: int, region_name: str, user_id: int
-) -> str:
-    """Compose a Final message on the list of ACTIVE searches in the given region"""
-
-    folder_url = f'{FORUM_FOLDER_PREFIX}{forum_folder_num}'
-    user_lat, user_lon = db_client.get_user_coordinates_or_none(user_id)
-    # Combine the list of the latest active searches
-
-    lines: list[str] = []
-
-    searches_list = db_client.get_active_searches_in_one_region(forum_folder_num)
-
-    for search in searches_list:
-        if time_counter_since_search_start(search.start_time)[1] >= 60:
-            continue
-
-        time_since_start = time_counter_since_search_start(search.start_time)[0]
-
-        if user_lat and user_lon and search.search_lat:
-            dist = define_dist_and_dir_to_search(search.search_lat, search.search_lon, user_lat, user_lon)
-            dist_and_dir = f' {dist[1]} {dist[0]} км'
-        else:
-            dist_and_dir = ''
-
-        if not search.display_name:
-            age_string = f' {age_writer(search.age)}' if search.age != 0 else ''
-            search.display_name = f'{search.name}{age_string}'
-
-        lines.append(
-            f'{time_since_start}{dist_and_dir} <a href="{SEARCH_URL_PREFIX}{search.topic_id}">{search.display_name}</a>'
-        )
-
-    msg = '\n'.join(lines)
-
-    if msg:
-        msg = f'Актуальные поиски за 60 дней в разделе <a href="{folder_url}">{region_name}</a>:\n{msg}'
-    else:
-        msg = f'В разделе <a href="{folder_url}">{region_name}</a> все поиски за последние 60 дней завершены.'
-
-    return msg
-
-
-def _handle_view_searches_usual_view(ctx: TGHandlerContext, search_list_type: SearchListType) -> None:
-    user_id = ctx.user_id
-    folders_list = ctx.db.get_geo_folders_db()
-
-    for forum_folder_num in ctx.db.get_user_reg_folders_preferences(user_id):
-        region_name = _get_region_name(folders_list, forum_folder_num)
-
-        # check if region – is an archive folder: if so – it can be sent only to 'all'
-        folder_is_archived = 'аверш' in region_name
-        if folder_is_archived and search_list_type != SearchListType.ALL:
-            continue
-
-        if search_list_type == SearchListType.ALL:
-            bot_message = _compose_text_message_of_all_searches(ctx.db, forum_folder_num, region_name)
-        else:
-            bot_message = _compose_text_message_on_active_searches(ctx.db, forum_folder_num, region_name, user_id)
-
-        ctx.send_message(text=bot_message, reply_markup=reply_markup_main)
-
-    _show_button_to_turn_on_following_searches(ctx)
-
-
-def _show_button_to_turn_on_following_searches(ctx: TGHandlerContext) -> None:
-    # issue425 add Button for turn on search following mode
-    search_follow_mode_ikb = [
-        [
-            InlineKeyboardButton(
-                text='Включить выбор поисков для отслеживания',
-                callback_data=InlineButtonCallbackData(action='search_follow_mode_on').as_str(),
-            )
-        ]
-    ]
-    reply_markup = InlineKeyboardMarkup(search_follow_mode_ikb)
-    ctx.tg_api.send_message(
-        ctx.user_id,
-        TelegramMessage(
-            text=(
-                'Вы можете включить возможность выбора поисков для отслеживания, '
-                'чтобы получать уведомления не со всех актуальных поисков, '
-                'а только с выбранных Вами.'
-            ),
-            reply_markup=reply_markup.to_dict(),
-        ),
-        f'{ctx.user_id=}, context_step=a01',
-    )
-
-
 def _handle_view_searches_experimental_view(ctx: TGHandlerContext, search_list_type: SearchListType) -> None:
     # issue#425 make inline keyboard - list of searches
     user_id = ctx.user_id
@@ -324,14 +212,6 @@ def _handle_view_searches_experimental_view(ctx: TGHandlerContext, search_list_t
                     )
                 ]
             )
-            region_data.rows.append(
-                [
-                    InlineKeyboardButton(
-                        text='Отключить выбор поисков для отслеживания',
-                        callback_data=InlineButtonCallbackData(action='search_follow_mode_off').as_str(),
-                    )
-                ]
-            )
 
         reply_markup_inline = InlineKeyboardMarkup(region_data.rows)
         logging.info(f'{bot_message=}; {region_data.rows=}; context_step=b00')
@@ -370,11 +250,7 @@ def handle_view_searches(ctx: TGHandlerContext) -> None:
     # диспетчер уходит в fallback «не понимаю такой команды».
     search_list_type = temp_dict[ctx.update_params.got_message.strip().lower()]
 
-    use_experimental_view = ctx.db.get_search_follow_mode(ctx.user_id) and (ctx.db.is_user_tester(ctx.user_id))
-    if use_experimental_view:
-        _handle_view_searches_experimental_view(ctx, search_list_type)
-    else:
-        _handle_view_searches_usual_view(ctx, search_list_type)
+    _handle_view_searches_experimental_view(ctx, search_list_type)
 
     # Ответы уходят через ctx.send_message()/ctx.tg_api.send_message(), которые
     # НЕ помечают контекст consumed. Без явной пометки диспетчер считает, что

--- a/tests/test_communicate/test_handlers/test_view_searches.py
+++ b/tests/test_communicate/test_handlers/test_view_searches.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock
 
 import pytest
 import sqlalchemy
+from telegram import InlineKeyboardMarkup
 
 from communicate import main
-from communicate._utils.common import UserInputState
+from communicate._utils.common import InlineButtonCallbackData, SearchSummary, UserInputState
 from communicate._utils.database import DBClient
 from communicate._utils.handler_context import TGHandlerContext
 from communicate._utils.handlers import view_searches_handlers
@@ -22,46 +23,6 @@ def region_id(session):
         {'region_id': _region_id},
     )
     session.commit()
-
-
-def test__compose_text_message_of_all_searches(db_client: DBClient, user_id: int, region_id: int):
-    count = 3
-    searches = db_factories.SearchFactory.create_batch_sync(
-        count,
-        forum_folder_id=region_id,
-        search_start_time=datetime.datetime.now(),
-        status='Ищем',
-    )
-    for search in searches:
-        db_factories.SearchHealthCheckFactory.create_sync(search_forum_num=search.search_forum_num, status='ok')
-
-    message = view_searches_handlers._compose_text_message_of_all_searches(db_client, region_id, 'name of region')
-
-    lines = message.splitlines()
-    assert len(lines) == count + 1
-    for search in searches:
-        assert search.display_name in message
-
-
-def test__compose_text_message_on_active_searches(db_client: DBClient, user_id: int, region_id: int):
-    count = 3
-    searches = db_factories.SearchFactory.create_batch_sync(
-        count,
-        forum_folder_id=region_id,
-        search_start_time=datetime.datetime.now(),
-        status='Ищем',
-    )
-    for search in searches:
-        db_factories.SearchHealthCheckFactory.create_sync(search_forum_num=search.search_forum_num, status='ok')
-
-    message = view_searches_handlers._compose_text_message_on_active_searches(
-        db_client, region_id, 'name of region', user_id
-    )
-
-    lines = message.splitlines()
-    assert len(lines) == count + 1
-    for search in searches:
-        assert search.display_name in message
 
 
 def test__compose_ikb_of_last_searches(db_client: DBClient, user_id: int, region_id: int):
@@ -122,12 +83,9 @@ def _make_update_params(text: str = 'посмотреть актуальные �
 def _make_db_mock() -> MagicMock:
     db_mock = MagicMock()
     db_mock.get_user_input_state.return_value = UserInputState.not_defined
-    db_mock.get_search_follow_mode.return_value = False
-    db_mock.is_user_tester.return_value = False
     db_mock.get_user_reg_folders_preferences.return_value = [1]
     db_mock.get_geo_folders_db.return_value = [(1, 'Москва')]
     db_mock.get_user_coordinates_or_none.return_value = (None, None)
-    db_mock.get_active_searches_in_one_region.return_value = []
     db_mock.get_active_searches_in_region_limit_20.return_value = []
     db_mock.get_all_last_searches_in_region_limit_20.return_value = []
     db_mock.get_folders_with_followed_searches.return_value = []
@@ -201,3 +159,117 @@ def test_handle_view_searches_case_insensitive_lookup(raw_text: str):
 
     assert consumed is True
     assert ctx.is_consumed
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Inline view is now the only production view (issue #38): the experimental
+# gate (get_search_follow_mode / is_user_tester) and the on/off toggle buttons
+# are gone; the follow-mode toggle callbacks must fall through silently.
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _make_search_summary() -> SearchSummary:
+    return SearchSummary(
+        topic_id=123,
+        name='Иванов',
+        display_name='Иванов',
+        status='Ищем',
+        new_status='Ищем',
+        start_time=datetime.datetime.now(),
+    )
+
+
+def test_handle_view_searches_always_uses_inline_view():
+    """The searches list must go inline without consulting the follow-mode gate."""
+    db_mock = _make_db_mock()
+    db_mock.get_active_searches_in_region_limit_20.return_value = [_make_search_summary()]
+    tg_api_mock = MagicMock()
+    ctx = TGHandlerContext(
+        update_params=_make_update_params(),
+        extra_params=MagicMock(),
+        db=db_mock,
+        tg_api=tg_api_mock,
+    )
+
+    consumed = main._run_registered_handlers(ctx, text='посмотреть актуальные поиски')
+
+    assert consumed is True
+    db_mock.get_search_follow_mode.assert_not_called()
+    db_mock.is_user_tester.assert_not_called()
+    inline_sent = any(
+        isinstance(call.args[1].reply_markup, InlineKeyboardMarkup)
+        for call in tg_api_mock.send_message.call_args_list
+    )
+    assert inline_sent, 'список поисков должен уходить inline-клавиатурой'
+
+
+def test_view_searches_keyboard_has_no_follow_mode_toggle():
+    """The keyboard keeps search_follow_clear but no longer has on/off toggles."""
+    db_mock = _make_db_mock()
+    db_mock.get_all_last_searches_in_region_limit_20.return_value = [_make_search_summary()]
+    tg_api_mock = MagicMock()
+    ctx = TGHandlerContext(
+        update_params=_make_update_params(),
+        extra_params=MagicMock(),
+        db=db_mock,
+        tg_api=tg_api_mock,
+    )
+
+    view_searches_handlers._handle_view_searches_experimental_view(ctx, view_searches_handlers.SearchListType.ALL)
+
+    actions = []
+    for call in tg_api_mock.send_message.call_args_list:
+        markup = call.args[1].reply_markup
+        if isinstance(markup, InlineKeyboardMarkup):
+            for row in markup.inline_keyboard:
+                for button in row:
+                    if button.callback_data is None:
+                        continue
+                    actions.append(InlineButtonCallbackData.deserialize(button.callback_data).action)
+
+    assert 'search_follow_mode_on' not in actions
+    assert 'search_follow_mode_off' not in actions
+    assert 'search_follow_clear' in actions
+
+
+def test_handle_search_follow_clear():
+    """Callback search_follow_clear must clear whiteness and reply."""
+    db_mock = _make_db_mock()
+    tg_api_mock = MagicMock()
+    update_params = _make_update_params()
+    update_params.got_callback = InlineButtonCallbackData(action='search_follow_clear')
+    ctx = TGHandlerContext(
+        update_params=update_params,
+        extra_params=MagicMock(),
+        db=db_mock,
+        tg_api=tg_api_mock,
+    )
+
+    consumed = main._run_registered_handlers(ctx, callback_data='search_follow_clear', callback_keyboard=None)
+
+    assert consumed is True
+    assert ctx.is_consumed
+    db_mock.delete_search_whiteness.assert_called_once_with(update_params.user_id)
+    reply_texts = [call.args[1].text for call in tg_api_mock.send_message.call_args_list]
+    assert any('Все пометки отслеживания поисков сброшены' in text for text in reply_texts)
+
+
+@pytest.mark.parametrize('action', ['search_follow_mode_on', 'search_follow_mode_off'])
+def test_removed_follow_mode_callbacks_fall_through_silently(action, monkeypatch):
+    """Stale on/off callbacks must be a silent no-op (no set, no fallback reply)."""
+    db_mock = _make_db_mock()
+    tg_api_mock = MagicMock()
+    monkeypatch.setattr('communicate.main.db', lambda: db_mock)
+    monkeypatch.setattr('communicate.main.tg_api', lambda: tg_api_mock)
+
+    update_params = _make_update_params(text='')
+    update_params.got_callback = InlineButtonCallbackData(action=action)
+    update_params.callback_query_id = 'q1'
+    update_params.callback_query = MagicMock()
+    extra_params = MagicMock()
+    extra_params.user_input_state = UserInputState.not_defined
+
+    main._run_handlers(update_params, extra_params)
+
+    db_mock.set_search_follow_mode.assert_not_called()
+    assert tg_api_mock.send_message.call_count == 0, 'устаревший callback должен завершаться молча'

--- a/tests/test_communicate/test_handlers/test_view_searches.py
+++ b/tests/test_communicate/test_handlers/test_view_searches.py
@@ -197,8 +197,7 @@ def test_handle_view_searches_always_uses_inline_view():
     db_mock.get_search_follow_mode.assert_not_called()
     db_mock.is_user_tester.assert_not_called()
     inline_sent = any(
-        isinstance(call.args[1].reply_markup, InlineKeyboardMarkup)
-        for call in tg_api_mock.send_message.call_args_list
+        isinstance(call.args[1].reply_markup, InlineKeyboardMarkup) for call in tg_api_mock.send_message.call_args_list
     )
     assert inline_sent, 'список поисков должен уходить inline-клавиатурой'
 


### PR DESCRIPTION
…sers (issue #38)

Remove the experimental gate (search_follow_mode + tester role) and the legacy plain-text view of the searches list. The inline keyboard with follow marks is now the only view.

- drop _handle_view_searches_usual_view and its helpers (_compose_text_message_of_all_searches, _compose_text_message_on_active_searches, _show_button_to_turn_on_following_searches)
- remove follow-mode toggle UI: search_follow_mode_on/off callbacks and the 'test search follow mode on/off' buttons; handle_search_follow_mode is now handle_search_follow_clear (search_follow_clear stays)
- keep search_follow_clear and manage_search_whiteness (mark toggling) intact
- notest still fully resets tester follow state (whiteness + follow mode)
- keep fixes: case-insensitive command lookup and ctx.mark_consumed()
- tests: drop plain-text view tests, add inline-only / no-toggle / silent fallback coverage